### PR TITLE
Potential fix for code scanning alert

### DIFF
--- a/crates/pjs-js-client/src/core/json-reconstructor.ts
+++ b/crates/pjs-js-client/src/core/json-reconstructor.ts
@@ -118,7 +118,7 @@ export class JsonReconstructor {
       }
       
       if (this.config.debug) {
-        console.log(`[PJS] Applied ${patch.operation} patch:`, {
+        console.log('[PJS] Applied patch operation:', patch.operation, {
           path: patch.path,
           operationCount: this.operationCount,
           hasValue: patch.value !== undefined


### PR DESCRIPTION
Potential fix for [https://github.com/bug-ops/pjs/security/code-scanning/261](https://github.com/bug-ops/pjs/security/code-scanning/261)

To fix the problem, we should avoid interpolating untrusted data directly into the format string of `console.log`. Instead, we should use a static format string and pass the untrusted data as a separate argument, so that it is treated as a value rather than a format string. Specifically, in `crates/pjs-js-client/src/core/json-reconstructor.ts`, line 121, change the log statement from:

```ts
console.log(`[PJS] Applied ${patch.operation} patch:`, { ... });
```

to:

```ts
console.log('[PJS] Applied patch operation:', patch.operation, { ... });
```

This ensures that `patch.operation` is not interpreted as a format string, and is instead logged as a value. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
