### PR TITLE
fix: update minimatch to 10.2.4 to resolve npm security vulnerabilities

### DIFF
--- a/crates/pjs-js-client/package-lock.json
+++ b/crates/pjs-js-client/package-lock.json
@@ -5378,9 +5378,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Updates `minimatch` from `10.2.2` to `10.2.4` in `crates/pjs-js-client/package-lock.json`
- Resolves two high-severity vulnerabilities (CVSS 7.5) in dev dependency:
  - [GHSA-23c5-xmqv-rm74](https://osv.dev/GHSA-23c5-xmqv-rm74)
  - [GHSA-7r86-cg39-jmmj](https://osv.dev/GHSA-7r86-cg39-jmmj)

## Test plan

- [x] OSV Security Scan passes
- [ ] NPM Package Validation passes