### PR TITLE
feat(parser): activate SIMD backend and wire AVX-512 feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Parser::new()` and `Parser::with_config()` honor `simd-*` Cargo features: the sonic-rs backend is selected only when a SIMD feature is enabled (default via `simd-auto`); with `--no-default-features` and no SIMD feature the portable `SimpleParser` is used (#115)
+- `simd-avx512` Cargo feature now forwards to `sonic-rs/avx512`, enabling AVX-512 codegen in sonic-rs when the feature is activated (#116)
 - `GetSystemStatsQuery` now reports real server uptime: `SystemQueryHandler` captures `Instant::now()` at construction and computes elapsed time on each query; `frames_per_second` and `bytes_per_second` are derived from actual uptime (#139)
 - Implement `QueryHandlerGat<GetStreamFramesQuery>` and `QueryHandlerGat<GetSessionStatsQuery>`; add HTTP routes `GET /pjs/sessions/:id/streams/:stream_id/frames` and `GET /pjs/sessions/:id/stats` (#141)
 - Remove `infrastructure/repositories/memory.rs` placeholder (`MemoryRepository` had no domain port implementations); delete the associated no-op test file; real in-memory storage is `GatInMemoryStreamRepository` (#133)

--- a/crates/pjs-core/Cargo.toml
+++ b/crates/pjs-core/Cargo.toml
@@ -70,7 +70,7 @@ default = ["simd-auto", "schema-validation"]
 # SIMD features
 simd-auto = []
 simd-avx2 = []
-simd-avx512 = []
+simd-avx512 = ["sonic-rs/avx512"]
 simd-neon = []
 simd-sse42 = []
 

--- a/crates/pjs-core/build.rs
+++ b/crates/pjs-core/build.rs
@@ -20,6 +20,7 @@ fn main() {
     println!("cargo::rustc-check-cfg=cfg(pjs_simd_sse42)");
     println!("cargo::rustc-check-cfg=cfg(pjs_simd_neon)");
     println!("cargo::rustc-check-cfg=cfg(pjs_simd_auto)");
+    println!("cargo::rustc-check-cfg=cfg(pjs_simd)");
 
     // Re-run only when these inputs change.
     println!("cargo::rerun-if-env-changed=CARGO_CFG_TARGET_FEATURE");
@@ -102,4 +103,8 @@ fn main() {
 
     // Unsupported feature combinations on non-matching architectures: silently no-op.
     // sonic-rs already handles the runtime fallback.
+
+    if want_auto || want_avx2 || want_avx512 || want_sse42 || want_neon {
+        println!("cargo::rustc-cfg=pjs_simd");
+    }
 }

--- a/crates/pjs-core/src/parser/mod.rs
+++ b/crates/pjs-core/src/parser/mod.rs
@@ -36,12 +36,16 @@ pub struct Parser {
 }
 
 impl Parser {
-    /// Create new parser with default configuration (sonic-rs enabled)
+    /// Create new parser with default configuration.
+    ///
+    /// Selects the sonic-rs SIMD backend when any `simd-*` Cargo feature is
+    /// enabled (which is the default via `simd-auto`). Without any `simd-*`
+    /// feature, falls back to the portable serde-based parser.
     pub fn new() -> Self {
         Self {
             sonic: SonicParser::new(),
             simple: SimpleParser::new(),
-            use_sonic: true,
+            use_sonic: cfg!(pjs_simd),
         }
     }
 
@@ -55,7 +59,7 @@ impl Parser {
         Self {
             sonic: SonicParser::with_config(sonic_config),
             simple: SimpleParser::with_config(config),
-            use_sonic: true,
+            use_sonic: cfg!(pjs_simd),
         }
     }
 


### PR DESCRIPTION
## Summary

- `Parser::new()` and `Parser::with_config()` now select the sonic-rs SIMD backend only when a `simd-*` Cargo feature is enabled (default: `simd-auto`); without any SIMD feature the portable `SimpleParser` is used
- `simd-avx512` feature now forwards to `sonic-rs/avx512`, enabling AVX-512 codegen on capable x86_64 hardware
- `build.rs` emits a unified `pjs_simd` cfg flag when any SIMD feature is requested, centralizing the "SIMD active" policy

Closes #115, closes #116

## Test plan

- [ ] `cargo nextest run --workspace --all-features --lib --bins` — all 788 tests pass
- [ ] `cargo build -p pjson-rs --no-default-features --features schema-validation` — compiles, uses `SimpleParser`
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean