### PR TITLE
fix(parser,stream): eliminate TODO stubs and unwrap calls in three hot-path sites

### DIFF
--- a/crates/pjs-core/src/parser/mod.rs
+++ b/crates/pjs-core/src/parser/mod.rs
@@ -112,11 +112,15 @@ impl Parser {
         }
     }
 
-    /// Get parser statistics (simplified for now)
+    /// Get parser statistics
     pub fn stats(&self) -> ParseStats {
         if self.use_sonic {
-            // TODO: Implement stats collection for sonic parser
-            ParseStats::default()
+            let sonic_stats = self.sonic.get_stats();
+            ParseStats {
+                total_parses: sonic_stats.total_parses,
+                semantic_detections: sonic_stats.sonic_successes,
+                avg_parse_time_ms: sonic_stats.avg_parse_time_ns as f64 / 1_000_000.0,
+            }
         } else {
             self.simple.stats()
         }

--- a/crates/pjs-core/src/parser/simple.rs
+++ b/crates/pjs-core/src/parser/simple.rs
@@ -168,11 +168,10 @@ impl SimpleParser {
 
             let value_fields: SmallVec<[String; 4]> = obj
                 .keys()
-                .filter(|k| {
-                    // TODO: Handle unwrap() - add proper error handling for object field access
-                    *k != timestamp_field && self.looks_like_numeric_value(obj.get(*k).unwrap())
+                .filter_map(|k| {
+                    let v = obj.get(k.as_str())?;
+                    (*k != timestamp_field && self.looks_like_numeric_value(v)).then(|| k.clone())
                 })
-                .cloned()
                 .collect();
 
             if !value_fields.is_empty() {

--- a/crates/pjs-core/src/stream/compression_integration.rs
+++ b/crates/pjs-core/src/stream/compression_integration.rs
@@ -178,17 +178,16 @@ impl StreamingCompressor {
 
         // Extract dictionary mappings
         for (key, value) in &compressed_data.compression_metadata {
-            if key.starts_with("dict_") {
-                if let Ok(index) = key.strip_prefix("dict_").unwrap().parse::<u16>()
+            if let Some(suffix) = key.strip_prefix("dict_") {
+                if let Ok(index) = suffix.parse::<u16>()
                     && let Some(string_val) = value.as_str()
                 {
                     dictionary_map.insert(index, string_val.to_string());
                 }
-            } else if key.starts_with("base_") {
-                let path = key.strip_prefix("base_").unwrap();
-                if let Some(num) = value.as_f64() {
-                    delta_bases.insert(path.to_string(), num);
-                }
+            } else if let Some(path) = key.strip_prefix("base_")
+                && let Some(num) = value.as_f64()
+            {
+                delta_bases.insert(path.to_string(), num);
             }
         }
 


### PR DESCRIPTION
## Summary

- **#155** `Parser::stats()` was always returning zero metrics when sonic-rs is active. Now delegates to `SonicParser::get_stats()` and maps `SonicStats` → `ParseStats`.
- **#150** `detect_object_semantics()` had an `.unwrap()` inside a `.filter()` closure on the primary parse path. Replaced with `.filter_map()` + `Option::then()`.
- **#151** `create_decompression_metadata()` used `starts_with()` + `strip_prefix().unwrap()` on both `"dict_"` and `"base_"` keys. Replaced with direct `if let Some(x) = key.strip_prefix(...)` pattern.

## Test plan

- [ ] `cargo +nightly fmt --check` — passes
- [ ] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — passes
- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 788 tests pass, 0 failures

Closes #155, #150, #151