### PR TITLE
fix(http,schema-validation): wire AdaptiveFrameStream fields and cache regex patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AdaptiveFrameStream::poll_next` now respects `buffer_size`: frames are prefetched into `current_buffer` and drained per-poll, enabling batched delivery (#163)
+- `AdaptiveFrameStream::with_compression(true)` now applies `SecureCompressor` (Gzip) to each formatted frame when the `compression` feature is active (#163)
+- `ValidationService::validate_string` no longer recompiles regex patterns on every call; compiled patterns are cached in a static `DashMap` and reused across invocations (#154)
+
 ### Added
 
 - Wire-level WebSocket integration tests that perform real protocol upgrades, frame exchange, and connection close verification (closes #158)

--- a/crates/pjs-core/src/domain/services/validation_service.rs
+++ b/crates/pjs-core/src/domain/services/validation_service.rs
@@ -10,6 +10,12 @@ use crate::domain::value_objects::{
     JsonData, Schema, SchemaValidationError, SchemaValidationResult,
 };
 
+#[cfg(feature = "schema-validation")]
+use {dashmap::DashMap, once_cell::sync::Lazy};
+
+#[cfg(feature = "schema-validation")]
+static REGEX_CACHE: Lazy<DashMap<String, regex::Regex>> = Lazy::new(DashMap::new);
+
 /// Schema validation service
 ///
 /// Validates JSON data against schema definitions following a subset of
@@ -336,11 +342,12 @@ impl ValidationService {
 
         #[cfg(feature = "schema-validation")]
         if let Some(pat) = pattern {
-            // TODO: cache compiled regexes to avoid recompiling on every call
-            let re = regex::Regex::new(pat).map_err(|e| SchemaValidationError::InvalidPattern {
-                path: path.to_string(),
-                pattern: pat.clone(),
-                reason: e.to_string(),
+            let re = REGEX_CACHE.entry(pat.clone()).or_try_insert_with(|| {
+                regex::Regex::new(pat).map_err(|e| SchemaValidationError::InvalidPattern {
+                    path: path.to_string(),
+                    pattern: pat.clone(),
+                    reason: e.to_string(),
+                })
             })?;
             if !re.is_match(value) {
                 return Err(SchemaValidationError::PatternMismatch {

--- a/crates/pjs-core/src/infrastructure/http/streaming.rs
+++ b/crates/pjs-core/src/infrastructure/http/streaming.rs
@@ -57,8 +57,8 @@ pub struct AdaptiveFrameStream<S> {
     format: StreamFormat,
     compression: bool,
     buffer_size: usize,
-    #[allow(dead_code)] // Future feature: adaptive batching implementation
-    current_buffer: Vec<String>,
+    current_buffer: Vec<Frame>,
+    inner_done: bool,
 }
 
 impl<S> AdaptiveFrameStream<S>
@@ -72,6 +72,7 @@ where
             compression: false,
             buffer_size: 10,
             current_buffer: Vec::new(),
+            inner_done: false,
         }
     }
 
@@ -101,11 +102,23 @@ where
             StreamFormat::ServerSentEvents => {
                 Ok(format!("data: {}\n\n", serde_json::to_string(&frame_data)?))
             }
-            StreamFormat::Binary => {
-                // Simplified binary format - would use more efficient encoding in production
-                Ok(serde_json::to_string(&frame_data)?)
-            }
+            StreamFormat::Binary => Ok(serde_json::to_string(&frame_data)?),
         }
+    }
+
+    fn maybe_compress(&self, formatted: String) -> Result<String, StreamError> {
+        #[cfg(feature = "compression")]
+        if self.compression {
+            use crate::compression::secure::{ByteCodec, SecureCompressor};
+            let compressor = SecureCompressor::with_default_security(ByteCodec::Gzip);
+            let compressed = compressor
+                .compress(formatted.as_bytes())
+                .map_err(|e| StreamError::Io(e.to_string()))?;
+            return Ok(String::from_utf8_lossy(&compressed.data).into_owned());
+        }
+        #[cfg(not(feature = "compression"))]
+        let _ = self.compression;
+        Ok(formatted)
     }
 }
 
@@ -116,14 +129,50 @@ where
     type Item = Result<String, StreamError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match Pin::new(&mut self.inner).poll_next(cx) {
-            Poll::Ready(Some(frame)) => {
-                let formatted = self.format_frame(&frame);
-                Poll::Ready(Some(formatted))
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+        // Drain a ready frame from the prefetch buffer before hitting the inner stream.
+        if !self.current_buffer.is_empty() {
+            let frame = self.current_buffer.remove(0);
+            let result = self
+                .format_frame(&frame)
+                .and_then(|s| self.maybe_compress(s));
+            return Poll::Ready(Some(result));
         }
+
+        if self.inner_done {
+            return Poll::Ready(None);
+        }
+
+        // Fill the prefetch buffer up to buffer_size from the inner stream.
+        loop {
+            match Pin::new(&mut self.inner).poll_next(cx) {
+                Poll::Ready(Some(frame)) => {
+                    self.current_buffer.push(frame);
+                    if self.current_buffer.len() >= self.buffer_size {
+                        break;
+                    }
+                }
+                Poll::Ready(None) => {
+                    self.inner_done = true;
+                    break;
+                }
+                Poll::Pending => {
+                    if self.current_buffer.is_empty() {
+                        return Poll::Pending;
+                    }
+                    break;
+                }
+            }
+        }
+
+        if self.current_buffer.is_empty() {
+            return Poll::Ready(None);
+        }
+
+        let frame = self.current_buffer.remove(0);
+        let result = self
+            .format_frame(&frame)
+            .and_then(|s| self.maybe_compress(s));
+        Poll::Ready(Some(result))
     }
 }
 


### PR DESCRIPTION
## Summary

- `AdaptiveFrameStream::poll_next` now prefetches frames into `current_buffer` up to `buffer_size` and drains one frame per poll — `with_buffer_size()` is no longer a no-op (#163)
- `with_compression(true)` applies `SecureCompressor` (Gzip) to each formatted frame when the `compression` feature is active (#163)
- `ValidationService::validate_string` caches compiled regex patterns in a static `DashMap`; subsequent calls for the same pattern reuse the compiled `Regex` instead of recompiling (#154)

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 814/814 passed
- [x] `cargo test --workspace --doc --all-features` — all doc tests passed

Closes #163, closes #154