### PR TITLE
fix(http): correct ApplicationError HTTP status codes and rename HttpExtensionConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `PjsError::Application` now maps `ApplicationError` variants to semantically correct HTTP status codes: `NotFound` → 404, `Validation` → 400, `Authorization` → 401, `Concurrency`/`Conflict` → 409, `Logic`/`Domain` → 500 (closes #173)
+- Renamed `infrastructure::http::PjsConfig` (HTTP extension config) to `HttpExtensionConfig` to eliminate name collision with the top-level `pjson_rs::PjsConfig` library config (closes #174)
 - `AdaptiveFrameStream::poll_next` now respects `buffer_size`: frames are prefetched into `current_buffer` and drained per-poll, enabling batched delivery (#163)
 - `AdaptiveFrameStream::with_compression(true)` now applies `SecureCompressor` (Gzip) to each formatted frame when the `compression` feature is active (#163)
 - `ValidationService::validate_string` no longer recompiles regex patterns on every call; compiled patterns are cached in a static `DashMap` and reused across invocations (#154)

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -793,7 +793,21 @@ pub enum PjsError {
 impl IntoResponse for PjsError {
     fn into_response(self) -> Response {
         let (status, error_message) = match &self {
-            PjsError::Application(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            PjsError::Application(app_err) => {
+                use crate::application::ApplicationError;
+                let status = match app_err {
+                    ApplicationError::NotFound(_) => StatusCode::NOT_FOUND,
+                    ApplicationError::Validation(_) => StatusCode::BAD_REQUEST,
+                    ApplicationError::Authorization(_) => StatusCode::UNAUTHORIZED,
+                    ApplicationError::Concurrency(_) | ApplicationError::Conflict(_) => {
+                        StatusCode::CONFLICT
+                    }
+                    ApplicationError::Domain(_) | ApplicationError::Logic(_) => {
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                };
+                (status, self.to_string())
+            }
             PjsError::InvalidSessionId(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             PjsError::InvalidStreamId(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             PjsError::InvalidPriority(_) => (StatusCode::BAD_REQUEST, self.to_string()),

--- a/crates/pjs-core/src/infrastructure/http/axum_extension.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_extension.rs
@@ -19,7 +19,7 @@ use crate::{Priority, PriorityStreamer};
 
 /// Configuration for PJS extension
 #[derive(Debug, Clone)]
-pub struct PjsConfig {
+pub struct HttpExtensionConfig {
     /// Route prefix for PJS endpoints (default: "/pjs")
     pub route_prefix: String,
     /// Enable automatic PJS detection based on Accept header
@@ -32,7 +32,7 @@ pub struct PjsConfig {
     pub session_timeout: Duration,
 }
 
-impl Default for PjsConfig {
+impl Default for HttpExtensionConfig {
     fn default() -> Self {
         Self {
             route_prefix: "/pjs".to_string(),
@@ -46,12 +46,12 @@ impl Default for PjsConfig {
 
 /// Universal PJS extension that can be added to any Axum router
 pub struct PjsExtension {
-    config: PjsConfig,
+    config: HttpExtensionConfig,
     streamer: Arc<PriorityStreamer>,
 }
 
 impl PjsExtension {
-    pub fn new(config: PjsConfig) -> Self {
+    pub fn new(config: HttpExtensionConfig) -> Self {
         Self {
             config,
             streamer: Arc::new(PriorityStreamer::new()),
@@ -149,7 +149,7 @@ pub struct StreamResponse {
 
 /// Handle stream creation request
 async fn handle_stream_request(
-    Extension(config): Extension<PjsConfig>,
+    Extension(config): Extension<HttpExtensionConfig>,
     Extension(streamer): Extension<Arc<PriorityStreamer>>,
     headers: HeaderMap,
     Json(request): Json<StreamRequest>,
@@ -338,7 +338,7 @@ mod tests {
         }
 
         // Create router with PJS extension
-        let config = PjsConfig::default();
+        let config = HttpExtensionConfig::default();
         let pjs_extension = PjsExtension::new(config);
 
         let app = Router::new().route("/api/users", get(api_route));
@@ -363,7 +363,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_auto_detection_middleware() {
-        let config = PjsConfig::default();
+        let config = HttpExtensionConfig::default();
         let _pjs_extension = Arc::new(PjsExtension::new(config));
 
         let _headers = HeaderMap::new();

--- a/crates/pjs-core/src/infrastructure/http/mod.rs
+++ b/crates/pjs-core/src/infrastructure/http/mod.rs
@@ -12,7 +12,7 @@ pub use axum_adapter::{
     StartStreamRequest, StreamParams, create_pjs_router, create_pjs_router_with_config,
     create_pjs_router_with_rate_limit, create_pjs_router_with_rate_limit_and_config,
 };
-pub use axum_extension::{PjsConfig, PjsExtension};
+pub use axum_extension::{HttpExtensionConfig, PjsExtension};
 pub use middleware::{RateLimitConfig, RateLimitMiddleware};
 pub use streaming::{
     AdaptiveFrameStream, BatchFrameStream, PriorityFrameStream, StreamError, StreamFormat,

--- a/crates/pjs-core/tests/http_axum_endpoints.rs
+++ b/crates/pjs-core/tests/http_axum_endpoints.rs
@@ -116,7 +116,7 @@ async fn test_get_session_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -179,7 +179,7 @@ async fn test_session_health_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -263,7 +263,7 @@ async fn test_create_stream_invalid_session() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -336,7 +336,7 @@ async fn test_start_stream_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -413,7 +413,7 @@ async fn test_get_stream_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // ===== System Health Tests =====
@@ -557,7 +557,7 @@ async fn test_get_session_stats_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -616,7 +616,7 @@ async fn test_get_stream_frames_not_found() {
 
     let response = app.oneshot(request).await.unwrap();
 
-    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // ===== Response Headers Tests =====

--- a/crates/pjs-core/tests/http_axum_extension_comprehensive.rs
+++ b/crates/pjs-core/tests/http_axum_extension_comprehensive.rs
@@ -23,7 +23,8 @@ use axum::{
 };
 use pjson_rs::Priority;
 use pjson_rs::infrastructure::http::axum_extension::{
-    PjsConfig, PjsExtension, PjsStreamingRequest, StreamError, StreamRequest, StreamResponse,
+    HttpExtensionConfig, PjsExtension, PjsStreamingRequest, StreamError, StreamRequest,
+    StreamResponse,
 };
 use serde_json::json;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ use tower::ServiceExt;
 
 #[test]
 fn test_pjs_config_default_values() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
 
     assert_eq!(config.route_prefix, "/pjs");
     assert!(config.auto_detect);
@@ -47,7 +48,7 @@ fn test_pjs_config_default_values() {
 
 #[test]
 fn test_pjs_config_custom_values() {
-    let config = PjsConfig {
+    let config = HttpExtensionConfig {
         route_prefix: "/api/stream".to_string(),
         auto_detect: false,
         default_priority: Priority::HIGH,
@@ -64,7 +65,7 @@ fn test_pjs_config_custom_values() {
 
 #[test]
 fn test_pjs_config_clone() {
-    let config1 = PjsConfig::default();
+    let config1 = HttpExtensionConfig::default();
     let config2 = config1.clone();
 
     assert_eq!(config1.route_prefix, config2.route_prefix);
@@ -78,7 +79,7 @@ fn test_pjs_config_clone() {
 
 #[test]
 fn test_pjs_extension_creation() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     // Extension created successfully
@@ -94,7 +95,7 @@ async fn test_pjs_extension_router_integration() {
         }))
     }
 
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new().route("/api/data", axum::routing::get(api_route));
@@ -118,7 +119,7 @@ async fn test_pjs_extension_router_integration() {
 
 #[tokio::test]
 async fn test_pjs_health_endpoint() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -146,7 +147,7 @@ async fn test_pjs_health_endpoint() {
 
 #[tokio::test]
 async fn test_pjs_health_endpoint_capabilities() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -174,7 +175,7 @@ async fn test_pjs_health_endpoint_capabilities() {
 
 #[tokio::test]
 async fn test_pjs_custom_route_prefix() {
-    let config = PjsConfig {
+    let config = HttpExtensionConfig {
         route_prefix: "/custom".to_string(),
         ..Default::default()
     };
@@ -310,7 +311,7 @@ fn test_stream_response_serialization() {
 
 #[tokio::test]
 async fn test_middleware_detects_pjs_stream_header() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     async fn test_handler(req: Request) -> impl IntoResponse {
@@ -343,7 +344,7 @@ async fn test_middleware_detects_pjs_stream_header() {
 
 #[tokio::test]
 async fn test_middleware_detects_sse_accept_header() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     async fn test_handler(req: Request) -> impl IntoResponse {
@@ -381,7 +382,7 @@ async fn test_middleware_detects_sse_accept_header() {
 
 #[tokio::test]
 async fn test_middleware_no_pjs_detection() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     async fn test_handler(req: Request) -> impl IntoResponse {
@@ -417,7 +418,7 @@ async fn test_middleware_no_pjs_detection() {
 
 #[tokio::test]
 async fn test_stream_request_endpoint_creates_stream() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -459,7 +460,7 @@ async fn test_stream_request_endpoint_creates_stream() {
 
 #[tokio::test]
 async fn test_stream_request_format_detection_from_accept_header() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -492,7 +493,7 @@ async fn test_stream_request_format_detection_from_accept_header() {
 
 #[tokio::test]
 async fn test_stream_request_format_detection_ndjson() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -527,7 +528,7 @@ async fn test_stream_request_format_detection_ndjson() {
 
 #[tokio::test]
 async fn test_sse_stream_endpoint_returns_event_stream() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();
@@ -562,7 +563,7 @@ async fn test_sse_stream_endpoint_returns_event_stream() {
 
 #[tokio::test]
 async fn test_sse_stream_endpoint_cors_headers() {
-    let config = PjsConfig::default();
+    let config = HttpExtensionConfig::default();
     let extension = PjsExtension::new(config);
 
     let app = Router::new();


### PR DESCRIPTION
## Summary

- `PjsError::Application` now maps each `ApplicationError` variant to the correct HTTP status code instead of unconditionally returning 500 (`NotFound` → 404, `Validation` → 400, `Authorization` → 401, `Concurrency`/`Conflict` → 409, `Logic`/`Domain` → 500)
- Renamed `infrastructure::http::PjsConfig` to `HttpExtensionConfig` to eliminate the public name collision with the top-level `pjson_rs::PjsConfig` library config; updated re-export in `mod.rs` and all usages in the integration test

## Test plan

- [x] `cargo +nightly fmt --check` — passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passes
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 828 passed, 0 failed

Closes #173, #174