### PR TITLE
fix(parser): add SAFETY comments to unsafe blocks and remove dead code

### DIFF
--- a/crates/pjs-core/src/application/handlers/query_handlers.rs
+++ b/crates/pjs-core/src/application/handlers/query_handlers.rs
@@ -9,7 +9,7 @@ use crate::{
         ports::{StreamRepositoryGat, StreamStoreGat},
     },
 };
-use std::{sync::Arc, time::Instant};
+use std::{marker::PhantomData, sync::Arc, time::Instant};
 
 /// Handler for session-related queries
 #[derive(Debug)]
@@ -296,8 +296,7 @@ where
     S: StreamStoreGat + 'static,
 {
     session_repository: Arc<R>,
-    #[allow(dead_code)]
-    stream_store: Arc<S>,
+    _phantom: PhantomData<S>,
 }
 
 impl<R, S> StreamQueryHandler<R, S>
@@ -305,10 +304,10 @@ where
     R: StreamRepositoryGat + 'static,
     S: StreamStoreGat + 'static,
 {
-    pub fn new(session_repository: Arc<R>, stream_store: Arc<S>) -> Self {
+    pub fn new(session_repository: Arc<R>, _stream_store: Arc<S>) -> Self {
         Self {
             session_repository,
-            stream_store,
+            _phantom: PhantomData,
         }
     }
 }

--- a/crates/pjs-core/src/application/services/event_service.rs
+++ b/crates/pjs-core/src/application/services/event_service.rs
@@ -336,53 +336,9 @@ where
 mod tests {
     use super::*;
     use crate::domain::{
-        events::{EventSubscriber, InMemoryEventStore},
+        events::InMemoryEventStore,
         value_objects::{SessionId, StreamId},
     };
-
-    // Mock subscriber for testing
-    #[allow(dead_code)] // Future test utility
-    struct MockSubscriber {
-        received_events: std::sync::Mutex<Vec<DomainEvent>>,
-    }
-
-    #[allow(dead_code)] // Future test utility
-    impl MockSubscriber {
-        fn new() -> Self {
-            Self {
-                received_events: std::sync::Mutex::new(Vec::new()),
-            }
-        }
-
-        fn event_count(&self) -> usize {
-            self.received_events
-                .lock()
-                .map(|events| events.len())
-                .unwrap_or(0)
-        }
-    }
-
-    impl EventSubscriber for MockSubscriber {
-        type HandleFuture<'a>
-            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
-        where
-            Self: 'a;
-
-        fn handle(&self, event: &DomainEvent) -> Self::HandleFuture<'_> {
-            let event = event.clone();
-            async move {
-                self.received_events
-                    .lock()
-                    .map_err(|_| {
-                        crate::domain::DomainError::Logic(
-                            "Event subscriber lock poisoned".to_string(),
-                        )
-                    })?
-                    .push(event);
-                Ok(())
-            }
-        }
-    }
 
     #[tokio::test]
     async fn test_event_service_creation() {

--- a/crates/pjs-core/src/application/services/optimization_service.rs
+++ b/crates/pjs-core/src/application/services/optimization_service.rs
@@ -8,8 +8,6 @@ use crate::{application::ApplicationResult, domain::value_objects::Priority};
 /// Service for optimization strategies and use case handling
 #[derive(Debug)]
 pub struct OptimizationService {
-    #[allow(dead_code)] // Future: will be used for default optimization selection
-    default_strategy: OptimizationStrategy,
     custom_strategies: std::collections::HashMap<String, OptimizationStrategy>,
 }
 
@@ -67,7 +65,6 @@ pub struct OptimizationMetrics {
 impl OptimizationService {
     pub fn new() -> Self {
         Self {
-            default_strategy: Self::create_balanced_strategy(),
             custom_strategies: std::collections::HashMap::new(),
         }
     }
@@ -313,19 +310,6 @@ impl OptimizationService {
             description: "Optimized for live streaming with audience interaction".to_string(),
             target_latency_ms: 500.0,
             target_throughput_mbps: 20.0,
-        }
-    }
-
-    fn create_balanced_strategy() -> OptimizationStrategy {
-        OptimizationStrategy {
-            priority_threshold: Priority::MEDIUM,
-            max_frame_size: 32 * 1024,
-            batch_size: 10,
-            compression_enabled: true,
-            adaptive_quality: true,
-            description: "Balanced strategy for general use cases".to_string(),
-            target_latency_ms: 500.0,
-            target_throughput_mbps: 10.0,
         }
     }
 

--- a/crates/pjs-core/src/application/services/performance_analysis_service.rs
+++ b/crates/pjs-core/src/application/services/performance_analysis_service.rs
@@ -116,23 +116,11 @@ impl MetricsHistory {
 /// Individual metric samples
 #[derive(Debug, Clone)]
 struct LatencySample {
-    #[allow(dead_code)] // Used for time-series analysis in future
-    timestamp: SystemTime,
-    #[allow(dead_code)] // Used for per-session metrics in future
-    session_id: SessionId,
-    #[allow(dead_code)] // Used for per-stream metrics in future
-    stream_id: Option<StreamId>,
     latency_ms: f64,
-    #[allow(dead_code)] // Used for operation-specific analysis in future
-    operation_type: String,
 }
 
 #[derive(Debug, Clone)]
 struct ThroughputSample {
-    #[allow(dead_code)] // Used for time-series analysis in future
-    timestamp: SystemTime,
-    #[allow(dead_code)] // Used for per-session metrics in future
-    session_id: SessionId,
     bytes_transferred: u64,
     duration: Duration,
     frame_count: usize,
@@ -140,20 +128,12 @@ struct ThroughputSample {
 
 #[derive(Debug, Clone)]
 struct ErrorSample {
-    #[allow(dead_code)] // Used for time-series analysis in future
-    timestamp: SystemTime,
-    #[allow(dead_code)] // Used for per-session metrics in future
-    session_id: SessionId,
-    #[allow(dead_code)] // Used for per-stream metrics in future
-    stream_id: Option<StreamId>,
     error_type: String,
     error_severity: ErrorSeverity,
 }
 
 #[derive(Debug, Clone)]
 struct ResourceSample {
-    #[allow(dead_code)] // Used for time-series analysis in future
-    timestamp: SystemTime,
     cpu_usage: f64,
     memory_usage_bytes: u64,
     network_bandwidth_mbps: f64,
@@ -180,18 +160,12 @@ impl PerformanceAnalysisService {
     /// Record a latency measurement
     pub fn record_latency(
         &mut self,
-        session_id: SessionId,
-        stream_id: Option<StreamId>,
+        _session_id: SessionId,
+        _stream_id: Option<StreamId>,
         latency_ms: f64,
-        operation_type: String,
+        _operation_type: String,
     ) -> ApplicationResult<()> {
-        let sample = LatencySample {
-            timestamp: SystemTime::now(),
-            session_id,
-            stream_id,
-            latency_ms,
-            operation_type,
-        };
+        let sample = LatencySample { latency_ms };
 
         self.metrics_history.add_latency_sample(sample);
         Ok(())
@@ -200,14 +174,12 @@ impl PerformanceAnalysisService {
     /// Record throughput measurement
     pub fn record_throughput(
         &mut self,
-        session_id: SessionId,
+        _session_id: SessionId,
         bytes_transferred: u64,
         duration: Duration,
         frame_count: usize,
     ) -> ApplicationResult<()> {
         let sample = ThroughputSample {
-            timestamp: SystemTime::now(),
-            session_id,
             bytes_transferred,
             duration,
             frame_count,
@@ -220,15 +192,12 @@ impl PerformanceAnalysisService {
     /// Record error occurrence
     pub fn record_error(
         &mut self,
-        session_id: SessionId,
-        stream_id: Option<StreamId>,
+        _session_id: SessionId,
+        _stream_id: Option<StreamId>,
         error_type: String,
         severity: ErrorSeverity,
     ) -> ApplicationResult<()> {
         let sample = ErrorSample {
-            timestamp: SystemTime::now(),
-            session_id,
-            stream_id,
             error_type,
             error_severity: severity,
         };
@@ -246,7 +215,6 @@ impl PerformanceAnalysisService {
         active_connections: usize,
     ) -> ApplicationResult<()> {
         let sample = ResourceSample {
-            timestamp: SystemTime::now(),
             cpu_usage,
             memory_usage_bytes,
             network_bandwidth_mbps,

--- a/crates/pjs-core/src/compression/mod.rs
+++ b/crates/pjs-core/src/compression/mod.rs
@@ -85,8 +85,6 @@ pub struct SchemaAnalyzer {
 #[derive(Debug, Clone)]
 struct PatternInfo {
     frequency: u32,
-    #[allow(dead_code)] // Future: used for compression ratio calculation
-    total_size: usize,
     compression_potential: f32,
 }
 
@@ -189,7 +187,6 @@ impl SchemaAnalyzer {
             if matching_count > self.config.min_frequency_count as usize {
                 let info = PatternInfo {
                     frequency: matching_count as u32,
-                    total_size: pattern.len() * matching_count,
                     compression_potential: (matching_count as f32 - 1.0) / matching_count as f32,
                 };
                 self.patterns.insert(structure_key, info);
@@ -213,7 +210,6 @@ impl SchemaAnalyzer {
                 if count > self.config.min_frequency_count {
                     let info = PatternInfo {
                         frequency: count,
-                        total_size: value_key.len() * count as usize,
                         compression_potential: (count as f32 - 1.0) / count as f32,
                     };
                     self.patterns
@@ -243,7 +239,6 @@ impl SchemaAnalyzer {
                     .entry(format!("url_prefix:{prefix}"))
                     .or_insert(PatternInfo {
                         frequency: 0,
-                        total_size: 0,
                         compression_potential: 0.0,
                     })
                     .frequency += 1;
@@ -255,7 +250,6 @@ impl SchemaAnalyzer {
                     .entry("uuid_pattern".to_string())
                     .or_insert(PatternInfo {
                         frequency: 0,
-                        total_size: 36,
                         compression_potential: self.config.uuid_compression_potential,
                     })
                     .frequency += 1;

--- a/crates/pjs-core/src/domain/aggregates/stream_session.rs
+++ b/crates/pjs-core/src/domain/aggregates/stream_session.rs
@@ -31,28 +31,6 @@ mod serde_session_id {
     }
 }
 
-/// Custom serde for StreamId within aggregates
-#[allow(dead_code)]
-mod serde_stream_id {
-    use crate::domain::value_objects::StreamId;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<S>(id: &StreamId, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        id.as_uuid().serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<StreamId, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let uuid = uuid::Uuid::deserialize(deserializer)?;
-        Ok(StreamId::from_uuid(uuid))
-    }
-}
-
 /// Custom serde for HashMap<StreamId, Stream>
 mod serde_stream_map {
     use crate::domain::{entities::Stream, value_objects::StreamId};

--- a/crates/pjs-core/src/infrastructure/adapters/event_publisher.rs
+++ b/crates/pjs-core/src/infrastructure/adapters/event_publisher.rs
@@ -519,44 +519,9 @@ impl EventPublisherGat for CompositeEventPublisher {
 mod tests {
     use super::*;
     use crate::domain::{
-        events::{DomainEvent, EventSubscriber},
+        events::DomainEvent,
         value_objects::{SessionId, StreamId},
     };
-    use std::sync::RwLock;
-
-    #[allow(dead_code)] // Future test utility
-    #[derive(Debug, Clone)]
-    struct TestSubscriber {
-        received_events: Arc<RwLock<Vec<DomainEvent>>>,
-    }
-
-    #[allow(dead_code)] // Future test utility
-    impl TestSubscriber {
-        fn new() -> Self {
-            Self {
-                received_events: Arc::new(RwLock::new(Vec::new())),
-            }
-        }
-
-        fn event_count(&self) -> usize {
-            self.received_events.read().unwrap().len()
-        }
-    }
-
-    impl EventSubscriber for TestSubscriber {
-        type HandleFuture<'a>
-            = impl std::future::Future<Output = DomainResult<()>> + Send + 'a
-        where
-            Self: 'a;
-
-        fn handle(&self, event: &DomainEvent) -> Self::HandleFuture<'_> {
-            let event = event.clone();
-            async move {
-                self.received_events.write().unwrap().push(event);
-                Ok(())
-            }
-        }
-    }
 
     #[tokio::test]
     async fn test_in_memory_event_publisher() {

--- a/crates/pjs-core/src/infrastructure/integration/object_pool.rs
+++ b/crates/pjs-core/src/infrastructure/integration/object_pool.rs
@@ -16,9 +16,6 @@ pub struct ObjectPool<T> {
     objects: ArrayQueue<T>,
     /// Factory function to create new objects
     factory: Arc<dyn Fn() -> T + Send + Sync>,
-    /// Maximum pool capacity
-    #[allow(dead_code)] // Future: used for pool size enforcement
-    max_capacity: usize,
     /// Best-effort stat counters — Relaxed ordering is intentional; these are
     /// metrics, not synchronization points, so occasional imprecision is acceptable.
     stat_created: AtomicUsize,
@@ -51,7 +48,6 @@ impl<T> ObjectPool<T> {
         Self {
             objects: ArrayQueue::new(capacity),
             factory: Arc::new(factory),
-            max_capacity: capacity,
             stat_created: AtomicUsize::new(0),
             stat_reused: AtomicUsize::new(0),
             stat_returned: AtomicUsize::new(0),
@@ -95,13 +91,6 @@ impl<T> ObjectPool<T> {
         // If pool is full, object is dropped (let GC handle it)
     }
 
-    /// Clean object before returning to pool (default implementation)
-    #[allow(dead_code)] // Future: will be used for type-specific cleaning strategies
-    fn clean_object(_obj: &mut T) {
-        // Default implementation does nothing
-        // Specialized implementations below for specific types
-    }
-
     /// Get current pool statistics
     pub fn stats(&self) -> PoolStats {
         PoolStats {
@@ -111,36 +100,6 @@ impl<T> ObjectPool<T> {
             peak_usage: self.stat_peak.load(Ordering::Relaxed),
             current_pool_size: self.stat_pool_size.load(Ordering::Relaxed),
         }
-    }
-}
-
-// Trait for cleanable objects
-#[allow(dead_code)] // Future: will be used for polymorphic cleaning
-trait Cleanable {
-    fn clean(&mut self);
-}
-
-impl Cleanable for HashMap<Cow<'static, str>, Cow<'static, str>> {
-    fn clean(&mut self) {
-        self.clear();
-    }
-}
-
-impl Cleanable for HashMap<String, String> {
-    fn clean(&mut self) {
-        self.clear();
-    }
-}
-
-impl Cleanable for Vec<u8> {
-    fn clean(&mut self) {
-        self.clear();
-    }
-}
-
-impl Cleanable for Vec<String> {
-    fn clean(&mut self) {
-        self.clear();
     }
 }
 
@@ -192,46 +151,6 @@ impl<'a, T> std::ops::DerefMut for PooledObject<'a, T> {
         self.get_mut()
     }
 }
-
-/// Global pools for common data structures
-pub struct GlobalPools {
-    pub cow_hashmap: ObjectPool<HashMap<Cow<'static, str>, Cow<'static, str>>>,
-    pub string_hashmap: ObjectPool<HashMap<String, String>>,
-    pub byte_vec: ObjectPool<Vec<u8>>,
-    pub string_vec: ObjectPool<Vec<String>>,
-}
-
-impl GlobalPools {
-    #[allow(dead_code)] // Future: will be exposed for global pool initialization
-    fn new() -> Self {
-        Self {
-            cow_hashmap: ObjectPool::new(50, || {
-                let mut map = HashMap::with_capacity(8);
-                map.shrink_to_fit(); // Ensure it's clean
-                map
-            }),
-            string_hashmap: ObjectPool::new(50, || {
-                let mut map = HashMap::with_capacity(8);
-                map.shrink_to_fit(); // Ensure it's clean
-                map
-            }),
-            byte_vec: ObjectPool::new(100, || {
-                let mut vec = Vec::with_capacity(1024);
-                vec.clear(); // Ensure it's clean
-                vec
-            }),
-            string_vec: ObjectPool::new(50, || {
-                let mut vec = Vec::with_capacity(16);
-                vec.clear(); // Ensure it's clean
-                vec
-            }),
-        }
-    }
-}
-
-/// Global singleton pools
-#[allow(dead_code)] // Future: will be used for global pool access pattern
-static GLOBAL_POOLS: Lazy<GlobalPools> = Lazy::new(GlobalPools::new);
 
 /// Wrapper that ensures cleaning happens
 pub struct CleaningPooledObject<T: 'static> {

--- a/crates/pjs-core/src/infrastructure/websocket/client.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/client.rs
@@ -36,12 +36,6 @@ struct StreamSession {
 /// Frame received by client
 #[derive(Debug, Clone)]
 struct ReceivedFrame {
-    #[allow(dead_code)] // Future feature: frame verification and replay
-    frame_id: u32,
-    #[allow(dead_code)] // Future feature: priority-based processing
-    priority: u8,
-    #[allow(dead_code)] // Future feature: frame-level data access
-    payload: Value,
     received_at: Instant,
     processed_at: Option<Instant>,
 }
@@ -260,7 +254,7 @@ impl PjsWebSocketClient {
             WsMessage::StreamFrame {
                 session_id,
                 frame_id,
-                priority,
+                priority: _priority,
                 payload,
                 is_complete,
             } => {
@@ -273,9 +267,6 @@ impl PjsWebSocketClient {
                     if let Some(session) = sessions.get_mut(&session_id) {
                         // Store received frame
                         let frame = ReceivedFrame {
-                            frame_id,
-                            priority,
-                            payload: payload.clone(),
                             received_at: processing_start,
                             processed_at: None,
                         };

--- a/crates/pjs-core/src/infrastructure/websocket/mod.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/mod.rs
@@ -4,8 +4,7 @@
 //! and backpressure handling for optimal client performance.
 
 use crate::{
-    Error as PjsError, PriorityStreamer, Result as PjsResult, StreamFrame, domain::Priority,
-    security::RateLimitGuard,
+    Error as PjsError, Result as PjsResult, StreamFrame, domain::Priority, security::RateLimitGuard,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -201,8 +200,6 @@ pub trait WebSocketTransport: Send + Sync {
 /// Adaptive streaming controller
 pub struct AdaptiveStreamController {
     sessions: Arc<RwLock<HashMap<String, StreamSession>>>,
-    #[allow(dead_code)] // Future feature: PriorityStreamer integration
-    streamer: PriorityStreamer,
     frame_tx: broadcast::Sender<(String, WsMessage)>,
 }
 
@@ -212,7 +209,6 @@ impl AdaptiveStreamController {
 
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
-            streamer: PriorityStreamer::new(),
             frame_tx,
         }
     }

--- a/crates/pjs-core/src/memory/arena.rs
+++ b/crates/pjs-core/src/memory/arena.rs
@@ -177,48 +177,6 @@ pub struct CombinedArenaStats {
     pub values_allocated: usize,
 }
 
-/// Arena-aware JSON parser for high-performance parsing
-#[allow(dead_code)]
-pub(crate) struct ArenaJsonParser {
-    arena: JsonArena,
-    reuse_threshold: usize,
-}
-
-#[allow(dead_code)]
-impl ArenaJsonParser {
-    /// Create new arena-backed parser
-    pub fn new() -> Self {
-        Self {
-            arena: JsonArena::new(),
-            reuse_threshold: 1000, // Reset arena after 1000 allocations
-        }
-    }
-
-    /// Parse JSON using arena allocation
-    pub fn parse(&mut self, json: &str) -> Result<serde_json::Value, serde_json::Error> {
-        // Check if we should reset arena to prevent unbounded growth
-        let stats = self.arena.stats();
-        if stats.values_allocated > self.reuse_threshold {
-            self.arena.reset();
-        }
-
-        // For now, fall back to standard parsing
-        // In a full implementation, you'd integrate arena allocation with the parser
-        serde_json::from_str(json)
-    }
-
-    /// Get current arena statistics
-    pub fn arena_stats(&self) -> CombinedArenaStats {
-        self.arena.stats()
-    }
-}
-
-impl Default for ArenaJsonParser {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,16 +212,6 @@ mod tests {
         assert_eq!(stats.objects_allocated, 0);
         assert_eq!(stats.arrays_allocated, 0);
         assert_eq!(stats.values_allocated, 0);
-    }
-
-    #[test]
-    fn test_arena_parser() {
-        let mut parser = ArenaJsonParser::new();
-        let result = parser.parse(r#"{"key": "value"}"#);
-
-        assert!(result.is_ok());
-        let value = result.unwrap();
-        assert!(value.is_object());
     }
 
     #[test]

--- a/crates/pjs-core/src/parser/buffer_pool.rs
+++ b/crates/pjs-core/src/parser/buffer_pool.rs
@@ -63,8 +63,6 @@ pub enum BufferSize {
 #[derive(Debug)]
 struct BufferBucket {
     buffers: Vec<AlignedBuffer>,
-    #[allow(dead_code)] // Future: size-based pool management
-    size: BufferSize,
     last_access: Instant,
 }
 
@@ -415,16 +413,28 @@ impl AlignedBuffer {
 
     /// Get mutable slice to buffer data
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: `self.ptr` was allocated via `AlignedAllocator::alloc_aligned` and remains
+        // valid for at least `self.capacity` bytes. `self.len <= self.capacity` is a class
+        // invariant upheld by every method that modifies `len`. The `&mut self` receiver
+        // ensures exclusive access for the lifetime of the returned slice.
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 
     /// Get immutable slice to buffer data
     pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: `self.ptr` was allocated via `AlignedAllocator::alloc_aligned` and remains
+        // valid for at least `self.capacity` bytes. `self.len <= self.capacity` is a class
+        // invariant upheld by every method that modifies `len`. The `&self` receiver ensures
+        // no mutable aliasing exists for the lifetime of the returned slice.
         unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
 
     /// Get a mutable slice with full capacity
     pub fn as_mut_capacity_slice(&mut self) -> &mut [u8] {
+        // SAFETY: `self.ptr` was allocated via `AlignedAllocator::alloc_aligned` for exactly
+        // `self.capacity` bytes. The `&mut self` receiver ensures exclusive access for the
+        // lifetime of the returned slice. Callers are responsible for initializing bytes
+        // before reading them; `set_len` is `unsafe` and documents that requirement.
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.capacity) }
     }
 
@@ -460,7 +470,11 @@ impl AlignedBuffer {
         // Use global SIMD allocator for reallocation
         let allocator = aligned_allocator();
 
-        // Reallocate using the allocator (which will handle data copying)
+        // Reallocate using the allocator (which will handle data copying).
+        // SAFETY: `self.ptr` was allocated (or previously reallocated) via
+        // `AlignedAllocator::alloc_aligned` with `self.layout`. `aligned_capacity` is
+        // positive because it is at least `new_capacity > self.capacity >= self.alignment`.
+        // After this call `self.ptr` must not be used — it is replaced below.
         let new_ptr =
             unsafe { allocator.realloc_aligned(self.ptr, self.layout, aligned_capacity)? };
 
@@ -487,6 +501,11 @@ impl AlignedBuffer {
             self.reserve(data.len())?;
         }
 
+        // SAFETY: `reserve` above ensures `self.capacity >= self.len + data.len()`, so
+        // `self.ptr.as_ptr().add(self.len)` is within the allocation. `data` is a valid
+        // `&[u8]` slice so its pointer is also valid for `data.len()` bytes. The destination
+        // range `[self.len, self.len + data.len())` does not overlap with `data` because
+        // `data` is an external caller-provided slice that cannot alias `self.ptr`.
         unsafe {
             ptr::copy_nonoverlapping(data.as_ptr(), self.ptr.as_ptr().add(self.len), data.len());
             self.len += data.len();
@@ -592,7 +611,12 @@ impl Clone for AlignedBuffer {
         let mut new_buffer =
             Self::new(self.capacity, self.alignment).expect("Failed to clone buffer");
 
-        // Copy data
+        // Copy data.
+        // SAFETY: `self.ptr` is valid for `self.len` bytes (allocation invariant).
+        // `new_buffer.ptr` is valid for `self.capacity` bytes because `Self::new` was called
+        // with `self.capacity` above. `self.len <= self.capacity` ensures the byte count fits
+        // in both ranges. The two allocations are independent heap regions, so they cannot
+        // overlap.
         unsafe {
             ptr::copy_nonoverlapping(self.ptr.as_ptr(), new_buffer.ptr.as_ptr(), self.len);
             new_buffer.len = self.len;
@@ -656,7 +680,6 @@ impl Drop for PooledBuffer {
             // Get or create bucket for this buffer size
             let mut bucket_ref = self.pool.entry(self.size).or_insert_with(|| BufferBucket {
                 buffers: Vec::new(),
-                size: self.size,
                 last_access: Instant::now(),
             });
 

--- a/crates/pjs-core/src/parser/mod.rs
+++ b/crates/pjs-core/src/parser/mod.rs
@@ -22,7 +22,7 @@ pub use simd_zero_copy::{
     SimdParseResult, SimdParsingStats, SimdZeroCopyConfig, SimdZeroCopyParser,
 };
 pub use simple::{ParseConfig, ParseStats, SimpleParser};
-pub use sonic::{LazyFrame, SonicConfig, SonicParser};
+pub use sonic::{SonicConfig, SonicParser};
 pub use value::{JsonValue, LazyArray, LazyObject};
 pub use zero_copy::{IncrementalParser, LazyJsonValue, LazyParser, MemoryUsage, ZeroCopyParser};
 

--- a/crates/pjs-core/src/parser/simd_zero_copy.rs
+++ b/crates/pjs-core/src/parser/simd_zero_copy.rs
@@ -20,8 +20,6 @@ pub struct SimdZeroCopyParser<'a> {
     input: &'a [u8],
     position: usize,
     depth: usize,
-    #[allow(dead_code)] // Future: depth limit enforcement
-    max_depth: usize,
     simd_enabled: bool,
     _phantom: PhantomData<&'a ()>,
 }
@@ -86,7 +84,6 @@ impl<'a> SimdZeroCopyParser<'a> {
             input: &[],
             position: 0,
             depth: 0,
-            max_depth: config.max_depth,
             simd_enabled: config.enable_simd && Self::is_simd_available(),
             _phantom: PhantomData,
         }
@@ -180,7 +177,6 @@ impl<'a> SimdZeroCopyParser<'a> {
         Ok(SonicStructuralInfo {
             value_type,
             start_pos: pos,
-            estimated_size: input.len(),
             has_escapes: self.detect_escapes(input),
             is_simd_friendly: self.is_simd_friendly(input),
         })
@@ -433,8 +429,6 @@ impl<'a> LazyParser<'a> for SimdZeroCopyParser<'a> {
 struct SonicStructuralInfo {
     value_type: ValueType,
     start_pos: usize,
-    #[allow(dead_code)] // Future: used for pre-allocation optimization
-    estimated_size: usize,
     has_escapes: bool,
     is_simd_friendly: bool,
 }

--- a/crates/pjs-core/src/parser/sonic.rs
+++ b/crates/pjs-core/src/parser/sonic.rs
@@ -423,20 +423,6 @@ impl SonicParser {
     }
 }
 
-/// Simplified lazy frame for future implementation
-pub struct LazyFrame<'a> {
-    frame: Frame,
-    #[allow(dead_code)] // Future: lazy evaluation of frame components
-    parser: &'a SonicParser,
-}
-
-impl<'a> LazyFrame<'a> {
-    /// Get the parsed frame
-    pub fn frame(&self) -> &Frame {
-        &self.frame
-    }
-}
-
 impl Default for SonicParser {
     fn default() -> Self {
         Self::new()

--- a/crates/pjs-core/src/parser/value.rs
+++ b/crates/pjs-core/src/parser/value.rs
@@ -30,9 +30,6 @@ pub struct LazyArray<'a> {
     raw: &'a [u8],
     /// Pre-computed element boundaries using SIMD scanning
     boundaries: SmallVec<[Range; 32]>,
-    /// Cache for parsed elements
-    #[allow(dead_code)] // Future: caching for repeated element access
-    cache: std::collections::HashMap<usize, JsonValue<'a>>,
 }
 
 /// Lazy object that parses fields on-demand
@@ -42,9 +39,6 @@ pub struct LazyObject<'a> {
     raw: &'a [u8],
     /// Pre-computed key-value boundaries
     fields: SmallVec<[FieldRange; 16]>,
-    /// Cache for parsed fields
-    #[allow(dead_code)] // Future: caching for repeated field access
-    cache: std::collections::HashMap<String, JsonValue<'a>>,
 }
 
 /// Field boundary information
@@ -130,11 +124,7 @@ impl<'a> LazyArray<'a> {
         // Extract array element boundaries from scan result
         let boundaries = Self::extract_element_boundaries(raw, &scan_result);
 
-        Self {
-            raw,
-            boundaries,
-            cache: std::collections::HashMap::new(),
-        }
+        Self { raw, boundaries }
     }
 
     /// Get array length
@@ -292,11 +282,7 @@ impl<'a> LazyObject<'a> {
     pub fn from_scan(raw: &'a [u8], scan_result: ScanResult) -> Self {
         let fields = Self::extract_field_boundaries(raw, &scan_result);
 
-        Self {
-            raw,
-            fields,
-            cache: std::collections::HashMap::new(),
-        }
+        Self { raw, fields }
     }
 
     /// Get number of fields

--- a/crates/pjs-core/src/parser/zero_copy.rs
+++ b/crates/pjs-core/src/parser/zero_copy.rs
@@ -580,11 +580,8 @@ impl MemoryUsage {
 
 /// Incremental parser for streaming scenarios
 pub struct IncrementalParser<'a> {
-    #[allow(dead_code)] // Future: base parser for incremental parsing
-    base: ZeroCopyParser<'a>,
     buffer: Vec<u8>,
-    #[allow(dead_code)] // Future: storage for parsed values in stream
-    complete_values: Vec<LazyJsonValue<'a>>,
+    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> Default for IncrementalParser<'a> {
@@ -596,9 +593,8 @@ impl<'a> Default for IncrementalParser<'a> {
 impl<'a> IncrementalParser<'a> {
     pub fn new() -> Self {
         Self {
-            base: ZeroCopyParser::new(),
             buffer: Vec::with_capacity(8192), // 8KB initial capacity
-            complete_values: Vec::new(),
+            _phantom: std::marker::PhantomData,
         }
     }
 

--- a/crates/pjs-domain/src/entities/frame.rs
+++ b/crates/pjs-domain/src/entities/frame.rs
@@ -374,13 +374,6 @@ pub enum PatchOperation {
     Delete,
 }
 
-/// Patch payload structure (reserved for future use)
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PatchPayload {
-    patches: Vec<FramePatch>,
-}
-
 impl FramePatch {
     /// Create set operation patch
     pub fn set(path: JsonPath, value: JsonData) -> Self {

--- a/crates/pjs-domain/src/entities/stream.rs
+++ b/crates/pjs-domain/src/entities/stream.rs
@@ -51,28 +51,6 @@ mod serde_stream_id {
     }
 }
 
-/// Custom serde for Priority within entities
-#[allow(dead_code)]
-mod serde_priority {
-    use crate::value_objects::Priority;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn serialize<S>(priority: &Priority, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        priority.value().serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Priority, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = u8::deserialize(deserializer)?;
-        Priority::new(value).map_err(serde::de::Error::custom)
-    }
-}
-
 /// Custom serde for HashMap<String, Priority>
 mod serde_priority_map {
     use crate::value_objects::Priority;

--- a/crates/pjs-domain/src/events/mod.rs
+++ b/crates/pjs-domain/src/events/mod.rs
@@ -47,7 +47,6 @@ mod serde_stream_id {
 }
 
 /// Custom serde for `Option<StreamId>`
-#[allow(dead_code)]
 mod serde_option_stream_id {
     use crate::value_objects::StreamId;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/pjs-domain/src/value_objects/priority.rs
+++ b/crates/pjs-domain/src/value_objects/priority.rs
@@ -148,87 +148,68 @@ impl TryFrom<u8> for Priority {
     }
 }
 
-/// Priority validation rules (reserved for future use)
-#[allow(dead_code)]
-pub trait PriorityRule {
-    fn validate(&self, priority: Priority) -> bool;
-    fn name(&self) -> &'static str;
-}
-
-/// Rule: Priority must be at least minimum value (reserved for future use)
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct MinimumPriority(pub Priority);
-
-#[allow(dead_code)]
-impl PriorityRule for MinimumPriority {
-    fn validate(&self, priority: Priority) -> bool {
-        priority >= self.0
-    }
-
-    fn name(&self) -> &'static str {
-        "minimum_priority"
-    }
-}
-
-/// Rule: Priority must be within range (reserved for future use)
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct PriorityRange {
-    pub min: Priority,
-    pub max: Priority,
-}
-
-#[allow(dead_code)]
-impl PriorityRule for PriorityRange {
-    fn validate(&self, priority: Priority) -> bool {
-        priority >= self.min && priority <= self.max
-    }
-
-    fn name(&self) -> &'static str {
-        "priority_range"
-    }
-}
-
-/// Collection of priority rules for validation (reserved for future use)
-#[allow(dead_code)]
-pub struct PriorityRules {
-    rules: Vec<Box<dyn PriorityRule + Send + Sync>>,
-}
-
-#[allow(dead_code)]
-impl PriorityRules {
-    pub fn new() -> Self {
-        Self { rules: Vec::new() }
-    }
-
-    pub fn add_rule(mut self, rule: impl PriorityRule + Send + Sync + 'static) -> Self {
-        self.rules.push(Box::new(rule));
-        self
-    }
-
-    pub fn validate(&self, priority: Priority) -> DomainResult<()> {
-        for rule in &self.rules {
-            if !rule.validate(priority) {
-                return Err(DomainError::InvalidPriority(format!(
-                    "Priority {priority} violates rule: {}",
-                    rule.name()
-                )));
-            }
-        }
-        Ok(())
-    }
-}
-
-impl Default for PriorityRules {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    trait PriorityRule {
+        fn validate(&self, priority: Priority) -> bool;
+        fn name(&self) -> &'static str;
+    }
+
+    struct MinimumPriority(Priority);
+
+    impl PriorityRule for MinimumPriority {
+        fn validate(&self, priority: Priority) -> bool {
+            priority >= self.0
+        }
+
+        fn name(&self) -> &'static str {
+            "minimum_priority"
+        }
+    }
+
+    struct PriorityRange {
+        min: Priority,
+        max: Priority,
+    }
+
+    impl PriorityRule for PriorityRange {
+        fn validate(&self, priority: Priority) -> bool {
+            priority >= self.min && priority <= self.max
+        }
+
+        fn name(&self) -> &'static str {
+            "priority_range"
+        }
+    }
+
+    struct PriorityRules {
+        rules: Vec<Box<dyn PriorityRule + Send + Sync>>,
+    }
+
+    impl PriorityRules {
+        fn new() -> Self {
+            Self { rules: Vec::new() }
+        }
+
+        fn add_rule(mut self, rule: impl PriorityRule + Send + Sync + 'static) -> Self {
+            self.rules.push(Box::new(rule));
+            self
+        }
+
+        fn validate(&self, priority: Priority) -> DomainResult<()> {
+            for rule in &self.rules {
+                if !rule.validate(priority) {
+                    return Err(DomainError::InvalidPriority(format!(
+                        "Priority {priority} violates rule: {}",
+                        rule.name()
+                    )));
+                }
+            }
+            Ok(())
+        }
+    }
 
     #[test]
     fn test_priority_constants() {


### PR DESCRIPTION
## Summary

- **#182**: Add `// SAFETY:` comments to 6 unsafe blocks in `AlignedBuffer` (`buffer_pool.rs`). Each comment documents the allocation invariant, the `len <= capacity` class invariant, and aliasing rules enforced by the receiver type — consistent with the style established in `aligned_alloc.rs`.
- **#185**: Remove all 48 `#[allow(dead_code)]` suppressions in `pjs-core` and `pjs-domain` by deleting the dead items and fixing all cascading call sites. Pre-v1.0.0 policy applies — no deprecation shims.

Notable deletions: `ArenaJsonParser`, `LazyFrame`, `GlobalPools`, `Cleanable` trait, `PatchPayload`, `TestSubscriber`, `MockSubscriber`, `BufferBucket::size`, and ~30 unused struct fields. `PriorityRule`/`MinimumPriority`/`PriorityRange`/`PriorityRules` are retained under `#[cfg(test)]` since they back meaningful test coverage.

Net: −459 lines / +93 lines across 21 files.

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo nextest run --workspace --all-features --lib --bins` — 827/827 passed

Closes #182
Closes #185