### PR TITLE
fix(config): restrict nextest default-filter to function-name prefix match

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-default-filter = 'not test(integration)'
+default-filter = 'not test(/^integration_/)'
 
 [profile.ci]
 default-filter = 'all()'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- nextest `default-filter` in `.config/nextest.toml` changed from `not test(integration)` (substring match on full test path) to `not test(/^integration_/)` (regex anchor on function name); restores 99 unit tests in `stream::compression_integration` and `infrastructure::integration` that were silently excluded (closes #200, resolves false 0% coverage in #195 and #196)
+- TODO(CQ-004) comment block before `pub enum PjsError` in `axum_adapter.rs` converted from `///` to `//`; eliminates misattributed rustdoc and spurious ignored doctest on `PjsError` (closes #193)
 - `pjs-wasm`: corrected module-level doc example in `lib.rs` — `PriorityStream.withSecurityConfig()` does not exist; replaced with `new PriorityStream()` + `stream.setSecurityConfig(security)` (closes #138)
 - `pjs-wasm`: corrected `PriorityConfigBuilder` doc example — `.build()` is not a JavaScript-visible method; replaced with `PjsParser.withConfig(config)` usage pattern (closes #140)
 - `PjsError::Application` now maps `ApplicationError` variants to semantically correct HTTP status codes: `NotFound` → 404, `Validation` → 400, `Authorization` → 401, `Concurrency`/`Conflict` → 409, `Logic`/`Domain` → 500 (closes #173)

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -750,27 +750,27 @@ where
     Ok(Json(response))
 }
 
-/// TODO(CQ-004): Implement HTTP rate limiting middleware
-///
-/// Recommended implementation:
-/// - Add Arc<WebSocketRateLimiter> to PjsAppState
-/// - Use 100 requests/minute per IP with burst allowance
-/// - Extract IP from ConnectInfo<SocketAddr>
-/// - Return 429 Too Many Requests on limit exceeded
-///
-/// Example:
-/// ```ignore
-/// async fn rate_limit_middleware(
-///     State(limiter): State<Arc<WebSocketRateLimiter>>,
-///     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-///     req: Request,
-///     next: Next,
-/// ) -> Result<Response, StatusCode> {
-///     limiter.check_request(addr.ip())
-///         .map_err(|_| StatusCode::TOO_MANY_REQUESTS)?;
-///     Ok(next.run(req).await)
-/// }
-/// ```
+// TODO(CQ-004): Implement HTTP rate limiting middleware
+//
+// Recommended implementation:
+// - Add Arc<WebSocketRateLimiter> to PjsAppState
+// - Use 100 requests/minute per IP with burst allowance
+// - Extract IP from ConnectInfo<SocketAddr>
+// - Return 429 Too Many Requests on limit exceeded
+//
+// Example:
+// ```ignore
+// async fn rate_limit_middleware(
+//     State(limiter): State<Arc<WebSocketRateLimiter>>,
+//     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+//     req: Request,
+//     next: Next,
+// ) -> Result<Response, StatusCode> {
+//     limiter.check_request(addr.ip())
+//         .map_err(|_| StatusCode::TOO_MANY_REQUESTS)?;
+//     Ok(next.run(req).await)
+// }
+// ```
 /// PJS-specific errors for HTTP endpoints
 #[derive(Debug, thiserror::Error)]
 pub enum PjsError {


### PR DESCRIPTION
## Summary

- Fixes `.config/nextest.toml` `default-filter`: changes `not test(integration)` (substring match on full test path) to `not test(/^integration_/)` (regex anchor on function name), restoring 99 silently excluded unit tests in `stream::compression_integration` and `infrastructure::integration`
- Converts the TODO(CQ-004) comment block before `pub enum PjsError` in `axum_adapter.rs` from `///` to `//`, eliminating misattributed rustdoc content and a spurious ignored doctest

## Test plan

- [x] `cargo nextest run --workspace --all-features --lib --bins` — 936 tests pass, 0 skipped (was 835 + 101 skipped before this fix)
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --doc --all-features` — clean

Closes #200, #193. Resolves false 0% coverage reported in #195, #196.