### PR TITLE
docs(pjson-rs): fix 6 broken intra-doc links and add pagination test assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed 6 broken intra-doc links in `global_alloc.rs`, `gat_memory_repository.rs`, and `auth.rs` that caused `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc` to fail; replaced unresolvable links with plain backtick text or qualified paths (closes #210)
+- `GetActiveSessionsQuery` and `SearchSessionsQuery` tests now assert `has_more` correctness and the 100-item page cap (closes #208)
 - nextest `default-filter` in `.config/nextest.toml` changed from `not test(integration)` (substring match on full test path) to `not test(/^integration_/)` (regex anchor on function name); restores 99 unit tests in `stream::compression_integration` and `infrastructure::integration` that were silently excluded (closes #200, resolves false 0% coverage in #195 and #196)
 - TODO(CQ-004) comment block before `pub enum PjsError` in `axum_adapter.rs` converted from `///` to `//`; eliminates misattributed rustdoc and spurious ignored doctest on `PjsError` (closes #193)
 - `pjs-wasm`: corrected module-level doc example in `lib.rs` — `PriorityStream.withSecurityConfig()` does not exist; replaced with `new PriorityStream()` + `stream.setSecurityConfig(security)` (closes #138)

--- a/crates/pjs-core/src/application/handlers/query_handlers.rs
+++ b/crates/pjs-core/src/application/handlers/query_handlers.rs
@@ -995,6 +995,49 @@ mod tests {
         let response = result.unwrap();
         assert_eq!(response.sessions.len(), 4);
         assert_eq!(response.total_count, 10);
+        assert!(response.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_get_active_sessions_last_page_has_more_false() {
+        let repository = Arc::new(MockRepository::new());
+        let handler = SessionQueryHandler::new(repository.clone());
+
+        for _ in 0..5 {
+            let mut session = StreamSession::new(SessionConfig::default());
+            let _ = session.activate();
+            repository.add_session(session);
+        }
+
+        // offset=3, limit=4 → only 2 remain → last page
+        let query = GetActiveSessionsQuery {
+            offset: Some(3),
+            limit: Some(4),
+        };
+        let response = handler.handle(query).await.unwrap();
+        assert_eq!(response.sessions.len(), 2);
+        assert!(!response.has_more);
+    }
+
+    #[tokio::test]
+    async fn test_get_active_sessions_page_cap() {
+        let repository = Arc::new(MockRepository::new());
+        let handler = SessionQueryHandler::new(repository.clone());
+
+        for _ in 0..110 {
+            let mut session = StreamSession::new(SessionConfig::default());
+            let _ = session.activate();
+            repository.add_session(session);
+        }
+
+        // limit=200 must be capped to 100
+        let query = GetActiveSessionsQuery {
+            offset: Some(0),
+            limit: Some(200),
+        };
+        let response = handler.handle(query).await.unwrap();
+        assert!(response.sessions.len() <= 100);
+        assert!(response.has_more);
     }
 
     #[tokio::test]
@@ -1332,7 +1375,9 @@ mod tests {
 
         let result = QueryHandlerGat::handle(&handler, query).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().sessions.len(), 1);
+        let response = result.unwrap();
+        assert_eq!(response.sessions.len(), 1);
+        assert!(!response.has_more);
     }
 
     #[tokio::test]
@@ -1354,7 +1399,9 @@ mod tests {
 
         let result = QueryHandlerGat::handle(&handler, query).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().sessions.len(), 0);
+        let response = result.unwrap();
+        assert_eq!(response.sessions.len(), 0);
+        assert!(!response.has_more);
     }
 
     #[tokio::test]
@@ -1376,7 +1423,9 @@ mod tests {
 
         let result = QueryHandlerGat::handle(&handler, query).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().sessions.len(), 0);
+        let response = result.unwrap();
+        assert_eq!(response.sessions.len(), 0);
+        assert!(!response.has_more);
     }
 
     #[tokio::test]
@@ -1396,7 +1445,9 @@ mod tests {
 
         let result = QueryHandlerGat::handle(&handler, query).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().sessions.len(), 2);
+        let response = result.unwrap();
+        assert_eq!(response.sessions.len(), 2);
+        assert!(!response.has_more);
     }
 
     #[tokio::test]
@@ -1419,6 +1470,8 @@ mod tests {
 
         let result = QueryHandlerGat::handle(&handler, query).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().sessions.len(), 1);
+        let response = result.unwrap();
+        assert_eq!(response.sessions.len(), 1);
+        assert!(!response.has_more);
     }
 }

--- a/crates/pjs-core/src/global_alloc.rs
+++ b/crates/pjs-core/src/global_alloc.rs
@@ -1,7 +1,7 @@
 //! Process-wide global allocator registration.
 //!
 //! When the `mimalloc` feature is enabled on a non-WASM target, registers
-//! [`mimalloc::MiMalloc`] as the `#[global_allocator]`. This routes all
+//! `mimalloc::MiMalloc` as the `#[global_allocator]`. This routes all
 //! `Box`/`Vec`/`String` allocations through mimalloc.
 //!
 //! On WASM (`target_arch = "wasm32"`) the system allocator is always used,

--- a/crates/pjs-core/src/infrastructure/adapters/gat_memory_repository.rs
+++ b/crates/pjs-core/src/infrastructure/adapters/gat_memory_repository.rs
@@ -4,7 +4,7 @@
 //!
 //! # Concurrency Model
 //!
-//! These repositories use [`InMemoryStore`] which is backed by `DashMap` for
+//! These repositories use [`InMemoryStore`](super::InMemoryStore) which is backed by `DashMap` for
 //! lock-free concurrent access. See `generic_store.rs` for detailed consistency
 //! guarantees.
 //!

--- a/crates/pjs-core/src/infrastructure/http/auth.rs
+++ b/crates/pjs-core/src/infrastructure/http/auth.rs
@@ -1,7 +1,7 @@
 //! HTTP authentication middleware for PJS endpoints.
 //!
-//! This module provides Tower [`Layer`] implementations for API key and (optionally) JWT
-//! authentication. Both layers mirror the boilerplate pattern of [`RateLimitMiddleware`]
+//! This module provides Tower `Layer` implementations for API key and (optionally) JWT
+//! authentication. Both layers mirror the boilerplate pattern of `RateLimitMiddleware`
 //! in `middleware.rs` so that they compose cleanly with the existing middleware stack.
 //!
 //! # Security design
@@ -11,7 +11,7 @@
 //! Raw API keys are never stored. At construction time each configured key is tagged with
 //! HMAC-SHA256 using a per-process random `hmac_key`. During authentication the candidate
 //! token is tagged with the same key and the resulting 32-byte digest is compared against
-//! every stored tag using [`ConstantTimeEq`].
+//! every stored tag using `ConstantTimeEq`.
 //!
 //! This design eliminates two side-channel classes:
 //! - **Length leakage** — all tags are exactly 32 bytes regardless of original key length.
@@ -32,7 +32,7 @@
 //! # Feature gates
 //!
 //! The entire module is gated behind `#[cfg(feature = "http-server")]`.
-//! [`JwtAuthLayer`] is additionally gated behind `#[cfg(feature = "http-auth-jwt")]`.
+//! `JwtAuthLayer` is additionally gated behind `#[cfg(feature = "http-auth-jwt")]`.
 
 #[cfg(feature = "http-server")]
 mod inner {
@@ -249,7 +249,7 @@ mod inner {
     /// Constant-time membership test.
     ///
     /// Tags the candidate with the stored HMAC key and compares against every stored tag
-    /// using [`ConstantTimeEq`]. The full list is always iterated — no early return —
+    /// using `ConstantTimeEq`. The full list is always iterated — no early return —
     /// and results are accumulated with bitwise OR to prevent timing-based key-index
     /// discovery.
     fn matches_any(state: &ApiKeyState, candidate: &[u8]) -> bool {


### PR DESCRIPTION
## Summary

- Fix 6 broken intra-doc links that caused `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc` to fail (closes #210)
- Add `has_more` and 100-item page-cap assertions to `GetActiveSessionsQuery` and `SearchSessionsQuery` tests (closes #208)

## Changes

**`global_alloc.rs`** — `mimalloc::MiMalloc` is an optional dep; replaced `[`mimalloc::MiMalloc`]` link with plain backtick text.

**`gat_memory_repository.rs`** — `InMemoryStore` is in sibling module; replaced bare `[`InMemoryStore`]` with `[`InMemoryStore`](super::InMemoryStore)`.

**`auth.rs`** — module-level `//!` docs are outside the `#[cfg(feature = "http-server")]` block so `tower::Layer`, `subtle::ConstantTimeEq`, `RateLimitMiddleware`, and `JwtAuthLayer` are all unresolvable; replaced with plain backtick text.

**`query_handlers.rs`** — added `assert!(response.has_more)` / `assert!(!response.has_more)` to all existing `GetActiveSessionsQuery` and `SearchSessionsQuery` tests; added two new tests:
- `test_get_active_sessions_last_page_has_more_false` — verifies `has_more=false` on the last page
- `test_get_active_sessions_page_cap` — verifies `limit=200` is capped to 100 and `has_more=true`

## Test plan

- [ ] `cargo +nightly fmt --check` — pass
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — pass
- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 967 tests pass (2 new)
- [ ] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjson-rs -p pjson-rs-domain` — 0 errors