### PR TITLE
fix(http): redact ApiKeyConfig Debug and wire SearchSessionsQuery route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `ApiKeyConfig` no longer derives `Debug`; a hand-written impl redacts `hmac_key` and `keys` fields, preventing HMAC key material from appearing in logs or panic output (closes #216)
+
+### Added
+
+- `GET /pjs/sessions/search` HTTP route dispatching to `SearchSessionsQuery`; supports `state`, `sort_by` (`created_at`, `updated_at`, `stream_count`, `total_bytes`), `sort_order` (`asc`/`ascending`, `desc`/`descending`), `limit`, and `offset` query parameters (closes #209)
+
 ### Changed
 
 - `AuthConfigError::RngFailure` now wraps the underlying `getrandom::Error` instead of discarding it, providing operators with actionable diagnostic information when the system RNG fails in sandboxed environments (closes #203)

--- a/crates/pjs-core/src/infrastructure/http/auth.rs
+++ b/crates/pjs-core/src/infrastructure/http/auth.rs
@@ -43,6 +43,7 @@ mod inner {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
     use std::{
+        fmt,
         future::Future,
         pin::Pin,
         sync::Arc,
@@ -101,10 +102,6 @@ mod inner {
     /// let config = ApiKeyConfig::new(&["secret-key-1", "secret-key-2"])?;
     /// let layer = ApiKeyAuthLayer::new(config);
     /// ```
-    // NOTE: Debug is derived but the fields contain HMAC key material. The output is
-    // formatted as arrays of integers which is not secret-safe in logs, but is needed for
-    // test assertions. Do not log ApiKeyConfig instances in production code.
-    #[derive(Debug)]
     pub struct ApiKeyConfig {
         /// HMAC-SHA256 tags of all configured API keys.
         pub(crate) keys: Vec<[u8; 32]>,
@@ -139,6 +136,15 @@ mod inner {
                 .map(|k| hmac_tag(&hmac_key, k.as_bytes()))
                 .collect();
             Ok(Self { keys, hmac_key })
+        }
+    }
+
+    impl fmt::Debug for ApiKeyConfig {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("ApiKeyConfig")
+                .field("keys", &format!("[{} redacted tags]", self.keys.len()))
+                .field("hmac_key", &"[redacted]")
+                .finish()
         }
     }
 
@@ -525,6 +531,20 @@ mod inner {
         use tower::{Service, ServiceExt};
 
         // ── ApiKeyConfig construction ────────────────────────────────────────────
+
+        #[test]
+        fn api_key_config_debug_redacts_key_material() {
+            let config = ApiKeyConfig::new(&["test-key-one"]).unwrap();
+            let debug = format!("{config:?}");
+            assert!(
+                debug.contains("redacted"),
+                "debug output must redact keys: {debug}"
+            );
+            assert!(
+                !debug.contains("hmac_key: ["),
+                "hmac_key must not appear as raw bytes: {debug}"
+            );
+        }
 
         #[test]
         fn empty_key_list_is_rejected() {

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -467,6 +467,7 @@ where
             "/pjs/sessions/{session_id}/streams/{stream_id}/frames",
             get(get_stream_frames::<R, P, S>),
         )
+        .route("/pjs/sessions/search", get(search_sessions::<R, P, S>))
         .route("/pjs/sessions", get(list_sessions::<R, P, S>))
         .route("/pjs/stats", get(get_system_stats::<R, P, S>))
 }
@@ -717,9 +718,63 @@ where
     Ok(Json(response))
 }
 
+/// Search sessions with filters and sorting.
+async fn search_sessions<R, P, S>(
+    State(state): State<PjsAppState<R, P, S>>,
+    Query(params): Query<SearchSessionsParams>,
+) -> Result<Json<SessionsResponse>, PjsError>
+where
+    R: StreamRepositoryGat + Send + Sync + 'static,
+    P: EventPublisherGat + Send + Sync + 'static,
+    S: StreamStoreGat + Send + Sync + 'static,
+{
+    let sort_by = params.sort_by.as_deref().and_then(|s| match s {
+        "created_at" => Some(SessionSortField::CreatedAt),
+        "updated_at" => Some(SessionSortField::UpdatedAt),
+        "stream_count" => Some(SessionSortField::StreamCount),
+        "total_bytes" => Some(SessionSortField::TotalBytes),
+        _ => None,
+    });
+    let sort_order = params.sort_order.as_deref().and_then(|s| match s {
+        "ascending" | "asc" => Some(SortOrder::Ascending),
+        "descending" | "desc" => Some(SortOrder::Descending),
+        _ => None,
+    });
+    let query = SearchSessionsQuery {
+        filters: SessionFilters {
+            state: params.state,
+            created_after: None,
+            created_before: None,
+            client_info: None,
+            has_active_streams: None,
+        },
+        sort_by,
+        sort_order,
+        limit: params.limit,
+        offset: params.offset,
+    };
+    let response = <SessionQueryHandler<R> as QueryHandlerGat<SearchSessionsQuery>>::handle(
+        &*state.session_query_handler,
+        query,
+    )
+    .await
+    .map_err(PjsError::Application)?;
+    Ok(Json(response))
+}
+
 /// Pagination parameters
 #[derive(Debug, Deserialize)]
 pub struct PaginationParams {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+/// Query parameters for session search endpoint.
+#[derive(Debug, Deserialize)]
+pub struct SearchSessionsParams {
+    pub state: Option<String>,
+    pub sort_by: Option<String>,
+    pub sort_order: Option<String>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
 }
@@ -1325,5 +1380,31 @@ mod tests {
                 &HttpServerConfig::default(),
             )
             .expect("router should build successfully with metrics feature");
+    }
+
+    #[tokio::test]
+    async fn search_sessions_route_returns_ok() {
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let repository = Arc::new(MockRepository::new());
+        let event_publisher = Arc::new(MockEventPublisher);
+        let stream_store = Arc::new(MockStreamStore);
+        let state = PjsAppState::new(repository, event_publisher, stream_store);
+
+        let router =
+            create_pjs_router_with_config::<MockRepository, MockEventPublisher, MockStreamStore>(
+                &HttpServerConfig::default(),
+            )
+            .expect("router should build")
+            .with_state(state);
+
+        let req = Request::builder()
+            .uri("/pjs/sessions/search")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `#[derive(Debug)]` on `ApiKeyConfig` with a hand-written impl that redacts `hmac_key` and `keys` fields, preventing HMAC key material from appearing in logs or panic output
- Adds `GET /pjs/sessions/search` HTTP route dispatching to `SearchSessionsQuery` with query parameters: `state`, `sort_by`, `sort_order`, `limit`, `offset`
- Adds test asserting Debug output contains "redacted" and does not expose raw byte arrays
- Adds smoke test for the new route

## Test plan

- [ ] `cargo nextest run --workspace --all-features --lib --bins` — 974 tests pass
- [ ] `cargo +nightly fmt --check` — no diffs
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [ ] `GET /pjs/sessions/search?state=active` returns 200 with sessions array
- [ ] `format!("{config:?}", config = ApiKeyConfig::new(&["k"])?)` → contains "redacted"

Closes #216, closes #209