### PR TITLE
feat(pjson-rs)!: add ZstdDictCompressor with trained-dictionary byte-level compression (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GET /pjs/sessions/search` HTTP route dispatching to `SearchSessionsQuery`; supports `state`, `sort_by` (`created_at`, `updated_at`, `stream_count`, `total_bytes`), `sort_order` (`asc`/`ascending`, `desc`/`descending`), `limit`, and `offset` query parameters (closes #209)
+- **`feature = "compression"`** — `ZstdDictCompressor` with per-session trained-dictionary compression (zstd 0.13, `zdict_builder`). Exposes `ZstdDictionary` newtype (type invariant: `len() ≤ 112 KiB`), `ZstdDictCompressor::train`, `compress`, and `decompress` (closes #144).
+- `ByteCodec::ZstdDict(Arc<ZstdDictionary>)` variant in `SecureCompressor` — encode/decode arms route through the bomb-detector byte-counting `run!` macro, same as all other codecs.
+- `DictionaryStore` trait and `NoopDictionaryStore` (zero-dep default) in `domain::ports` — hand-rolled `Pin<Box<dyn Future>>` port; no `async-trait` dependency.
+- `InMemoryDictionaryStore` (behind `compression` + non-wasm32) — per-session corpus accumulation with `tokio::sync::OnceCell`-guarded one-time training. `register()` for pre-trained dictionaries; `train_if_ready()` for incremental corpus growth. Both call the bomb-detector as a size-budget gate.
+- `GET /pjs/sessions/{session_id}/dictionary` HTTP endpoint (behind `http-server` + `compression` + non-wasm32) — returns the trained dictionary with `Content-Type: application/zstd-dictionary` and `Cache-Control: private, max-age=300` once `N_TRAIN` (32) frame samples are accumulated.
+- `PjsAppState::with_dictionary_store(repo, publisher, store, dict_store)` — four-arg constructor that enables the dictionary endpoint end-to-end; existing `PjsAppState::new` defaults to `NoopDictionaryStore` (no behaviour change for existing callers).
+- `pjs-demo`: interactive demo server now instantiates `InMemoryDictionaryStore` at startup and prints the dictionary endpoint path.
 
 ### Changed
+
+- **BREAKING** `ByteCodec` no longer implements `Copy` — the new `ZstdDict(Arc<ZstdDictionary>)` variant requires `Clone`. Callers that relied on implicit copy semantics must call `.clone()` explicitly. Pre-1.0 breaking change; no deprecation cycle.
 
 - `AuthConfigError::RngFailure` now wraps the underlying `getrandom::Error` instead of discarding it, providing operators with actionable diagnostic information when the system RNG fails in sandboxed environments (closes #203)
 - Fixed inverted layer ordering diagram in `create_pjs_router_with_rate_limit_and_auth` doc comment; the diagram now correctly shows `rate_limit` as the outermost layer wrapping both public and protected sub-routers, with `auth` as an inner layer on protected routes only (closes #204)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,6 +1787,7 @@ dependencies = [
  "typed-arena",
  "url",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -1801,6 +1802,12 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -3882,3 +3889,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ url = "2.5"
 uuid = "1.23"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
+zstd = { version = "0.13", default-features = false, features = ["zdict_builder"] }
 
 [profile.release]
 opt-level = 3

--- a/crates/pjs-core/Cargo.toml
+++ b/crates/pjs-core/Cargo.toml
@@ -63,6 +63,7 @@ tracing = { workspace = true }
 typed-arena = { workspace = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -92,7 +93,7 @@ simd-sse42 = []
 mimalloc = ["dep:mimalloc"]
 
 # Optional features
-compression = ["dep:brotli", "dep:flate2"]
+compression = ["dep:brotli", "dep:flate2", "dep:zstd"]
 partial-parse = ["dep:jiter"]
 schema-validation = ["dep:regex"]
 

--- a/crates/pjs-core/src/compression/mod.rs
+++ b/crates/pjs-core/src/compression/mod.rs
@@ -5,6 +5,9 @@
 
 pub mod secure;
 
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+pub mod zstd;
+
 use crate::domain::{DomainError, DomainResult};
 use serde_json::{Value as JsonValue, json};
 use std::collections::HashMap;

--- a/crates/pjs-core/src/compression/secure.rs
+++ b/crates/pjs-core/src/compression/secure.rs
@@ -23,6 +23,8 @@ use crate::{
 use std::io::Write;
 use std::io::{Cursor, Read};
 use tracing::{debug, info, warn};
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+use zstd;
 
 /// Byte-level compression algorithms used by [`SecureCompressor`].
 ///
@@ -31,7 +33,13 @@ use tracing::{debug, info, warn};
 /// (Layer B).
 ///
 /// Codecs other than `None` require the `compression` feature.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// # Breaking change (pre-1.0)
+///
+/// `Copy` was removed from this enum when `ZstdDict` was added (it carries an
+/// `Arc<ZstdDictionary>`).  Code that relied on implicit copy can use `.clone()`
+/// (one atomic refcount bump for `ZstdDict`; a no-op for the other variants).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ByteCodec {
     /// No compression — bytes stored verbatim. Always available.
     #[default]
@@ -52,6 +60,20 @@ pub enum ByteCodec {
     ///
     /// Requires `feature = "compression"`.
     Brotli,
+    /// Trained zstd dictionary compression.
+    ///
+    /// A single `Arc<ZstdDictionary>` is the canonical sharing primitive. The inner
+    /// `Vec<u8>` inside [`crate::compression::zstd::ZstdDictionary`] is **not**
+    /// `Arc`-wrapped — sharing happens exactly once at this enum level (avoids
+    /// double indirection). Cloning this variant performs one atomic refcount
+    /// increment and no allocation.
+    ///
+    /// Equality compares the underlying bytes via `Arc<T>: PartialEq where T: PartialEq`.
+    /// When both sides share the same `Arc` allocation, `Arc::ptr_eq` provides a fast path.
+    ///
+    /// Requires `feature = "compression"` on a non-`wasm32` target.
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    ZstdDict(std::sync::Arc<crate::compression::zstd::ZstdDictionary>),
 }
 
 /// Quality knob for byte-level codecs.
@@ -176,7 +198,7 @@ impl SecureCompressor {
         Ok(SecureCompressedData {
             original_size: data.len(),
             compression_ratio,
-            codec: self.codec,
+            codec: self.codec.clone(),
             data: compressed_bytes,
         })
     }
@@ -188,7 +210,7 @@ impl SecureCompressor {
     pub fn decompress_protected(&self, compressed: &SecureCompressedData) -> Result<Vec<u8>> {
         self.detector
             .validate_pre_decompression(compressed.data.len())?;
-        self.decode_with_protection(&compressed.data, compressed.codec, None)
+        self.decode_with_protection(&compressed.data, compressed.codec.clone(), None)
     }
 
     /// Decompress nested/chained compression with depth tracking.
@@ -202,12 +224,12 @@ impl SecureCompressor {
     ) -> Result<Vec<u8>> {
         self.detector
             .validate_pre_decompression(compressed.data.len())?;
-        self.decode_with_protection(&compressed.data, compressed.codec, Some(depth))
+        self.decode_with_protection(&compressed.data, compressed.codec.clone(), Some(depth))
     }
 
     /// Encode `data` with the configured codec. Returns compressed bytes only.
     fn encode(&self, data: &[u8]) -> Result<Vec<u8>> {
-        match self.codec {
+        match &self.codec {
             ByteCodec::None => {
                 debug!("No compression applied");
                 Ok(data.to_vec())
@@ -243,6 +265,11 @@ impl SecureCompressor {
                 brotli::BrotliCompress(&mut Cursor::new(data), &mut out, &params)
                     .map_err(|e| Error::CompressionError(format!("brotli encode: {e}")))?;
                 Ok(out)
+            }
+
+            #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+            ByteCodec::ZstdDict(dict) => {
+                crate::compression::zstd::ZstdDictCompressor::compress(data, dict.as_ref())
             }
 
             #[cfg(not(feature = "compression"))]
@@ -315,6 +342,20 @@ impl SecureCompressor {
 
             #[cfg(feature = "compression")]
             ByteCodec::Brotli => run!(brotli::Decompressor::new(Cursor::new(data), 4096)),
+
+            // ZstdDict uses the streaming decoder so every decompressed byte
+            // passes through the CompressionBombProtector's read loop (run!).
+            // Bulk `zstd::bulk::Decompressor::decompress` is intentionally
+            // avoided here — it would bypass the byte-level output cap.
+            #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+            ByteCodec::ZstdDict(dict) => {
+                let decoder = zstd::stream::read::Decoder::with_dictionary(
+                    Cursor::new(data),
+                    dict.as_bytes(),
+                )
+                .map_err(|e| Error::CompressionError(format!("zstd decoder init: {e}")))?;
+                run!(decoder)
+            }
 
             #[cfg(not(feature = "compression"))]
             ByteCodec::Deflate | ByteCodec::Gzip | ByteCodec::Brotli => Err(
@@ -652,9 +693,9 @@ mod tests {
     }
 
     #[test]
-    fn test_byte_codec_clone_and_copy() {
+    fn test_byte_codec_clone() {
         let codec = ByteCodec::None;
-        let cloned = codec;
+        let cloned = codec.clone();
         assert_eq!(codec, cloned);
     }
 
@@ -693,6 +734,124 @@ mod tests {
         let compressed = c.compress(data).unwrap();
         let decompressed = c.decompress_nested(&compressed, 0).unwrap();
         assert_eq!(decompressed.as_slice(), data);
+    }
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    mod zstd_dict_tests {
+        use super::*;
+        use crate::compression::zstd::{MAX_DICT_SIZE, N_TRAIN, ZstdDictCompressor};
+        use crate::security::CompressionBombConfig;
+        use std::sync::Arc;
+
+        fn repetitive_json() -> Vec<u8> {
+            let item = br#"{"id":1,"name":"test","value":42,"active":true}"#;
+            item.repeat(100)
+        }
+
+        fn trained_dict() -> crate::compression::zstd::ZstdDictionary {
+            let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+                .map(|i| {
+                    format!(
+                        r#"{{"id":{i},"name":"item-{i}","value":{},"active":true}}"#,
+                        i * 10
+                    )
+                    .into_bytes()
+                })
+                .collect();
+            ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap()
+        }
+
+        #[test]
+        fn test_zstd_dict_roundtrip_via_secure_compressor() {
+            let dict = Arc::new(trained_dict());
+            let compressor =
+                SecureCompressor::with_default_security(ByteCodec::ZstdDict(dict.clone()));
+            let data = repetitive_json();
+
+            let compressed = compressor.compress(&data).unwrap();
+            assert!(matches!(compressed.codec, ByteCodec::ZstdDict(_)));
+            assert!(
+                compressed.data.len() < data.len(),
+                "zstd dict must reduce size on repetitive data"
+            );
+
+            let decompressed = compressor.decompress_protected(&compressed).unwrap();
+            assert_eq!(decompressed, data);
+        }
+
+        #[test]
+        fn test_zstd_dict_bomb_detection() {
+            let dict = Arc::new(trained_dict());
+            let producer =
+                SecureCompressor::with_default_security(ByteCodec::ZstdDict(dict.clone()));
+            let data = repetitive_json();
+            let compressed = producer.compress(&data).unwrap();
+
+            let config = CompressionBombConfig {
+                max_decompressed_size: 200,
+                max_compressed_size: 10_000,
+                max_ratio: 300.0,
+                check_interval_bytes: 64,
+                ..Default::default()
+            };
+            let strict = SecureCompressor::new(
+                crate::security::CompressionBombDetector::new(config),
+                ByteCodec::ZstdDict(dict),
+            );
+            let result = strict.decompress_protected(&compressed);
+            assert!(
+                result.is_err(),
+                "bomb detector must block oversized zstd dict output"
+            );
+        }
+
+        #[test]
+        fn test_zstd_dict_codec_mismatch_errors() {
+            let dict = Arc::new(trained_dict());
+            let c = SecureCompressor::with_default_security(ByteCodec::ZstdDict(dict));
+            let data = b"codec mismatch test data";
+            let mut compressed = c.compress(data).unwrap();
+            // Lie about the codec — decoding as Gzip must fail.
+            compressed.codec = ByteCodec::Gzip;
+            assert!(
+                c.decompress_protected(&compressed).is_err(),
+                "wrong codec must produce an error"
+            );
+        }
+
+        #[test]
+        fn test_zstd_dict_empty_payload_roundtrip() {
+            let dict = Arc::new(trained_dict());
+            let c = SecureCompressor::with_default_security(ByteCodec::ZstdDict(dict));
+            let compressed = c.compress(b"").unwrap();
+            let decompressed = c.decompress_protected(&compressed).unwrap();
+            assert_eq!(decompressed, b"");
+        }
+
+        #[test]
+        fn test_zstd_dict_wrong_dictionary_errors() {
+            // Build two independent dictionaries from distinct corpora.
+            let samples_a: Vec<Vec<u8>> = (0..N_TRAIN)
+                .map(|i| format!(r#"{{"corpus":"alpha","id":{i},"score":{}}}"#, i * 7).into_bytes())
+                .collect();
+            let samples_b: Vec<Vec<u8>> = (0..N_TRAIN)
+                .map(|i| format!(r#"{{"corpus":"beta","seq":{i},"label":"x-{i}"}}"#).into_bytes())
+                .collect();
+
+            let dict_a = ZstdDictCompressor::train(&samples_a, MAX_DICT_SIZE).unwrap();
+            let dict_b = ZstdDictCompressor::train(&samples_b, MAX_DICT_SIZE).unwrap();
+
+            let data = b"some representative payload data";
+            let compressed =
+                ZstdDictCompressor::compress(data, &dict_a).expect("compress with dict_a");
+
+            // Decompressing dict_a-compressed bytes with dict_b must fail at libzstd level.
+            let result = ZstdDictCompressor::decompress(&compressed, &dict_b, data.len() * 4);
+            assert!(
+                result.is_err(),
+                "wrong dictionary must produce a libzstd error"
+            );
+        }
     }
 
     #[cfg(feature = "compression")]
@@ -867,10 +1026,11 @@ mod tests {
         #[test]
         fn test_empty_payload_all_codecs() {
             for codec in [ByteCodec::Deflate, ByteCodec::Gzip, ByteCodec::Brotli] {
+                let label = format!("{codec:?}");
                 let c = SecureCompressor::with_default_security(codec);
                 let compressed = c.compress(b"").unwrap();
                 let decompressed = c.decompress_protected(&compressed).unwrap();
-                assert_eq!(decompressed, b"", "empty roundtrip failed for {codec:?}");
+                assert_eq!(decompressed, b"", "empty roundtrip failed for {label}");
             }
         }
     }

--- a/crates/pjs-core/src/compression/zstd.rs
+++ b/crates/pjs-core/src/compression/zstd.rs
@@ -1,0 +1,439 @@
+//! Trained-dictionary zstd compression for PJS byte-level transport (Layer B).
+//!
+//! Provides [`ZstdDictionary`] (a validated opaque blob carrying the libzstd
+//! dictionary) and [`ZstdDictCompressor`] (a stateless driver for training,
+//! compression, and standalone decompression).
+//!
+//! The hot-path decompression used by [`crate::compression::secure::SecureCompressor`]
+//! is intentionally **not** exposed here: it uses a streaming decoder routed
+//! through `CompressionBombProtector` so the output-size guard still applies.
+//! This module's `decompress` is only for callers that need a standalone,
+//! non-bomb-protected path (e.g., tests or tools where the size is already known).
+//!
+//! Available only when `feature = "compression"` is enabled and the target is
+//! not `wasm32`.
+
+use crate::{Error, Result};
+
+/// Maximum permitted dictionary size in bytes (112 KiB).
+///
+/// This is the **type invariant** of [`ZstdDictionary`]: any value of that type
+/// satisfies `len() <= MAX_DICT_SIZE`. The constant is conservative — libzstd
+/// can produce dictionaries up to 2 GiB, but large dicts inflate RSS on every
+/// session and slow context initialisation. 112 KiB covers the sweet spot for
+/// JSON-like payloads.
+pub const MAX_DICT_SIZE: usize = 112 * 1024;
+
+/// Number of training samples required before [`ZstdDictCompressor::train`] is
+/// called.  Libzstd requires at least 8 samples; `N_TRAIN` is set to 32 so
+/// the resulting dictionary captures representative variance across a session.
+/// Below this threshold [`crate::domain::ports::dictionary_store::DictionaryStore::get_dictionary`]
+/// returns `Ok(None)`.
+pub const N_TRAIN: usize = 32;
+
+/// Default zstd compression level used by [`ZstdDictCompressor::compress`].
+///
+/// Level 3 is the libzstd default: a good balance of speed and ratio for
+/// repetitive JSON-like workloads. Pass an explicit level to
+/// [`ZstdDictCompressor::compress_with_level`] if you need to tune it.
+pub const DEFAULT_LEVEL: i32 = 3;
+
+/// zstd dictionary magic bytes (little-endian `0xEC30A437`).
+const ZSTD_MAGIC: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
+
+/// A validated, size-bounded zstd dictionary blob.
+///
+/// **Type invariant:** `self.len() <= MAX_DICT_SIZE` (112 KiB) and the first
+/// four bytes are the zstd dictionary magic `0xEC30A437`. All public
+/// constructors funnel through the private `new_checked` gate; callers outside
+/// this module cannot construct an invalid value.
+///
+/// Sharing is performed once at the enum level via `Arc<ZstdDictionary>` in
+/// [`crate::compression::secure::ByteCodec::ZstdDict`].  The inner `Vec<u8>`
+/// is intentionally not wrapped in a second `Arc` — that would create
+/// double indirection with no benefit.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+/// # {
+/// use pjson_rs::compression::zstd::{ZstdDictCompressor, ZstdDictionary, N_TRAIN};
+///
+/// // Build enough samples for training (at least 8 needed by libzstd; N_TRAIN = 32).
+/// let item = b"{\"id\":1,\"name\":\"test\",\"value\":42,\"active\":true}";
+/// let samples: Vec<Vec<u8>> = (0..N_TRAIN).map(|i| {
+///     format!("{{\"id\":{i},\"name\":\"item\",\"value\":{},\"active\":true}}", i * 10)
+///         .into_bytes()
+/// }).collect();
+///
+/// let dict = ZstdDictCompressor::train(&samples, 65536).expect("training should succeed");
+/// assert!(dict.len() <= 65536);
+/// assert!(!dict.is_empty());
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZstdDictionary(Vec<u8>);
+
+impl ZstdDictionary {
+    /// Private constructor — the single enforcement point for the type invariant.
+    fn new_checked(bytes: Vec<u8>) -> Result<Self> {
+        if bytes.is_empty() {
+            return Err(Error::CompressionError("zstd: empty dictionary".into()));
+        }
+        if bytes.len() > MAX_DICT_SIZE {
+            return Err(Error::CompressionError(format!(
+                "zstd: dictionary size {} exceeds MAX_DICT_SIZE ({})",
+                bytes.len(),
+                MAX_DICT_SIZE
+            )));
+        }
+        if bytes.len() < 4 || bytes[0..4] != ZSTD_MAGIC {
+            return Err(Error::CompressionError(
+                "zstd: invalid dictionary magic (expected 0xEC30A437)".into(),
+            ));
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Construct a [`ZstdDictionary`] from a raw byte blob produced by libzstd.
+    ///
+    /// Validates the magic header and the 112 KiB size cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] if:
+    /// - `bytes` is empty
+    /// - `bytes.len() > MAX_DICT_SIZE`
+    /// - the first four bytes are not the zstd dictionary magic `0xEC30A437`
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use pjson_rs::compression::zstd::ZstdDictionary;
+    ///
+    /// // Empty bytes are rejected.
+    /// assert!(ZstdDictionary::from_bytes(vec![]).is_err());
+    ///
+    /// // Bytes without the correct magic are rejected.
+    /// assert!(ZstdDictionary::from_bytes(vec![0x00, 0x01, 0x02, 0x03]).is_err());
+    ///
+    /// // A blob larger than MAX_DICT_SIZE is rejected.
+    /// use pjson_rs::compression::zstd::MAX_DICT_SIZE;
+    /// let oversized = vec![0x37u8, 0xA4, 0x30, 0xEC]
+    ///     .into_iter()
+    ///     .chain(std::iter::repeat(0u8).take(MAX_DICT_SIZE))
+    ///     .collect::<Vec<_>>();
+    /// assert!(ZstdDictionary::from_bytes(oversized).is_err());
+    /// # }
+    /// ```
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        Self::new_checked(bytes)
+    }
+
+    /// Returns the raw dictionary bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns the dictionary size in bytes (always `<= MAX_DICT_SIZE`).
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the dictionary has no bytes.
+    ///
+    /// This can never be `true` for a successfully constructed [`ZstdDictionary`]
+    /// because `new_checked` rejects empty inputs. The method exists to satisfy
+    /// Clippy's `len_without_is_empty` requirement.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Stateless driver for zstd dictionary operations.
+///
+/// All methods take the dictionary by reference. No internal state is retained
+/// between calls; callers supply both the data and the dictionary each time.
+///
+/// The trained dictionary should be stored in
+/// [`crate::infrastructure::repositories::InMemoryDictionaryStore`] (or a
+/// custom [`crate::domain::ports::dictionary_store::DictionaryStore`] impl)
+/// and shared via `Arc<ZstdDictionary>`.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+/// # {
+/// use pjson_rs::compression::zstd::{ZstdDictCompressor, N_TRAIN, MAX_DICT_SIZE};
+///
+/// let samples: Vec<Vec<u8>> = (0..N_TRAIN).map(|i| {
+///     format!("{{\"id\":{i},\"key\":\"value\",\"score\":{}}}", i * 3).into_bytes()
+/// }).collect();
+///
+/// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+///
+/// let data = b"{\"id\":99,\"key\":\"value\",\"score\":297}";
+/// let compressed = ZstdDictCompressor::compress(data, &dict).unwrap();
+/// let decompressed = ZstdDictCompressor::decompress(&compressed, &dict, data.len() * 2).unwrap();
+/// assert_eq!(decompressed, data);
+/// # }
+/// ```
+pub struct ZstdDictCompressor;
+
+impl ZstdDictCompressor {
+    /// Train a zstd dictionary from a corpus of sample byte strings.
+    ///
+    /// `max_dict_size` is **clamped** to [`MAX_DICT_SIZE`] before being passed to
+    /// libzstd — even if the caller requests a larger dict, the type invariant of
+    /// [`ZstdDictionary`] is always satisfied.
+    ///
+    /// Libzstd requires at least 8 samples; the PJS convention is to call this
+    /// after accumulating [`N_TRAIN`] (32) samples for better dictionary quality.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] if:
+    /// - `samples.len() < 8` (libzstd hard minimum)
+    /// - libzstd training itself fails (e.g., samples too small or too uniform)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use pjson_rs::compression::zstd::{ZstdDictCompressor, N_TRAIN, MAX_DICT_SIZE};
+    ///
+    /// let samples: Vec<Vec<u8>> = (0..N_TRAIN).map(|i| {
+    ///     format!("{{\"seq\":{i},\"payload\":\"aaabbbccc{i}\"}}").into_bytes()
+    /// }).collect();
+    ///
+    /// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+    /// assert!(dict.len() <= MAX_DICT_SIZE);
+    ///
+    /// // Requesting a larger size is silently clamped.
+    /// let dict2 = ZstdDictCompressor::train(&samples, usize::MAX).unwrap();
+    /// assert!(dict2.len() <= MAX_DICT_SIZE);
+    ///
+    /// // Insufficient samples are rejected before calling libzstd.
+    /// let few: Vec<Vec<u8>> = vec![b"data".to_vec(); 3];
+    /// assert!(ZstdDictCompressor::train(&few, MAX_DICT_SIZE).is_err());
+    /// # }
+    /// ```
+    pub fn train(samples: &[Vec<u8>], max_dict_size: usize) -> Result<ZstdDictionary> {
+        // Libzstd requires ≥ 8 samples; reject early with a clear message.
+        if samples.len() < 8 {
+            return Err(Error::CompressionError(format!(
+                "zstd: insufficient samples ({} provided, need >= 8)",
+                samples.len()
+            )));
+        }
+        let cap = max_dict_size.min(MAX_DICT_SIZE);
+        let bytes = zstd::dict::from_samples(samples, cap)
+            .map_err(|e| Error::CompressionError(format!("zstd: train: {e}")))?;
+        // Defence-in-depth: re-check even if libzstd honoured the size cap.
+        ZstdDictionary::new_checked(bytes)
+    }
+
+    /// Compress `data` using the dictionary at the default level ([`DEFAULT_LEVEL`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] on libzstd failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use pjson_rs::compression::zstd::{ZstdDictCompressor, N_TRAIN, MAX_DICT_SIZE};
+    ///
+    /// let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+    ///     .map(|i| format!("{{\"n\":{i}}}").into_bytes())
+    ///     .collect();
+    /// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+    /// let compressed = ZstdDictCompressor::compress(b"{\"n\":99}", &dict).unwrap();
+    /// assert!(!compressed.is_empty());
+    /// # }
+    /// ```
+    pub fn compress(data: &[u8], dict: &ZstdDictionary) -> Result<Vec<u8>> {
+        Self::compress_with_level(data, dict, DEFAULT_LEVEL)
+    }
+
+    /// Compress `data` using the dictionary at an explicit compression level.
+    ///
+    /// Level must be in `[1, 22]`; libzstd clamps out-of-range values silently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] on libzstd failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use pjson_rs::compression::zstd::{ZstdDictCompressor, N_TRAIN, MAX_DICT_SIZE};
+    ///
+    /// let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+    ///     .map(|i| format!("{{\"n\":{i}}}").into_bytes())
+    ///     .collect();
+    /// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+    /// let compressed = ZstdDictCompressor::compress_with_level(b"{\"n\":99}", &dict, 1).unwrap();
+    /// assert!(!compressed.is_empty());
+    /// # }
+    /// ```
+    pub fn compress_with_level(data: &[u8], dict: &ZstdDictionary, level: i32) -> Result<Vec<u8>> {
+        // TODO(#144 follow-up): per-session compressor cache once benchmarks justify it.
+        let mut compressor = zstd::bulk::Compressor::with_dictionary(level, dict.as_bytes())
+            .map_err(|e| Error::CompressionError(format!("zstd: compressor init: {e}")))?;
+        compressor
+            .compress(data)
+            .map_err(|e| Error::CompressionError(format!("zstd: compress: {e}")))
+    }
+
+    /// Decompress `data` using the dictionary, capping output at `max_output` bytes.
+    ///
+    /// This is the **standalone** decompression path — for untrusted input routed
+    /// through [`crate::compression::secure::SecureCompressor`], use
+    /// [`crate::compression::secure::ByteCodec::ZstdDict`] instead, which passes the
+    /// output through [`crate::security::CompressionBombDetector`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] on libzstd failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use pjson_rs::compression::zstd::{ZstdDictCompressor, N_TRAIN, MAX_DICT_SIZE};
+    ///
+    /// let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+    ///     .map(|i| format!("{{\"n\":{i}}}").into_bytes())
+    ///     .collect();
+    /// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+    /// let data = b"{\"n\":99}";
+    /// let compressed = ZstdDictCompressor::compress(data, &dict).unwrap();
+    /// let decompressed = ZstdDictCompressor::decompress(&compressed, &dict, 1024).unwrap();
+    /// assert_eq!(decompressed.as_slice(), data.as_slice());
+    /// # }
+    /// ```
+    pub fn decompress(data: &[u8], dict: &ZstdDictionary, max_output: usize) -> Result<Vec<u8>> {
+        let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict.as_bytes())
+            .map_err(|e| Error::CompressionError(format!("zstd: decompressor init: {e}")))?;
+        decompressor
+            .decompress(data, max_output)
+            .map_err(|e| Error::CompressionError(format!("zstd: decompress: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Generate a training corpus with `count` JSON samples.
+    fn make_samples(count: usize) -> Vec<Vec<u8>> {
+        (0..count)
+            .map(|i| {
+                format!(
+                    r#"{{"id":{i},"name":"item-{i}","value":{val},"active":true}}"#,
+                    val = i * 10
+                )
+                .into_bytes()
+            })
+            .collect()
+    }
+
+    // ~4 KiB of repetitive JSON — should compress well with a trained dict.
+    fn repetitive_json() -> Vec<u8> {
+        let item = br#"{"id":1,"name":"test","value":42,"active":true}"#;
+        item.repeat(100)
+    }
+
+    #[test]
+    fn test_train_compress_decompress_roundtrip() {
+        let samples = make_samples(N_TRAIN);
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+
+        let data = repetitive_json();
+        let compressed = ZstdDictCompressor::compress(&data, &dict).unwrap();
+        let decompressed =
+            ZstdDictCompressor::decompress(&compressed, &dict, data.len() * 2).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_train_insufficient_samples_error() {
+        let samples = make_samples(3);
+        let err = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("insufficient samples"),
+            "error should mention insufficient samples: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_train_clamps_to_max_dict_size() {
+        let samples = make_samples(N_TRAIN);
+        // Requesting more than MAX_DICT_SIZE must still produce a valid (≤ cap) dict.
+        let dict = ZstdDictCompressor::train(&samples, usize::MAX).unwrap();
+        assert!(
+            dict.len() <= MAX_DICT_SIZE,
+            "dict size {} exceeds MAX_DICT_SIZE",
+            dict.len()
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_empty() {
+        assert!(ZstdDictionary::from_bytes(vec![]).is_err());
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_invalid_magic() {
+        assert!(ZstdDictionary::from_bytes(vec![0x00, 0x01, 0x02, 0x03]).is_err());
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_oversized() {
+        let mut bytes = ZSTD_MAGIC.to_vec();
+        bytes.extend(std::iter::repeat_n(0u8, MAX_DICT_SIZE));
+        // Total length = 4 + MAX_DICT_SIZE > MAX_DICT_SIZE → must fail.
+        assert!(ZstdDictionary::from_bytes(bytes).is_err());
+    }
+
+    #[test]
+    fn test_compress_with_level() {
+        let samples = make_samples(N_TRAIN);
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+        let data = repetitive_json();
+
+        // Level 1 and level 9 must both produce valid compressed output.
+        for level in [1, 9] {
+            let c = ZstdDictCompressor::compress_with_level(&data, &dict, level).unwrap();
+            let d = ZstdDictCompressor::decompress(&c, &dict, data.len() * 2).unwrap();
+            assert_eq!(d, data, "level {level} roundtrip failed");
+        }
+    }
+
+    #[test]
+    fn test_dictionary_equality() {
+        let samples = make_samples(N_TRAIN);
+        let d1 = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+        let d2 = d1.clone();
+        assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn test_is_empty_is_always_false_for_valid_dict() {
+        let samples = make_samples(N_TRAIN);
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+        assert!(!dict.is_empty());
+    }
+}

--- a/crates/pjs-core/src/domain/ports/dictionary_store.rs
+++ b/crates/pjs-core/src/domain/ports/dictionary_store.rs
@@ -1,0 +1,161 @@
+//! Port: resolve trained zstd dictionaries by session id.
+//!
+//! Intentionally **not** under `ports::gat` — the GAT pattern is reserved for
+//! hot-path ports where allocation cost matters. This port is invoked at most
+//! once per HTTP dictionary request and once per sample submission. A boxed
+//! future avoids pulling in `async-trait` as a dependency while staying
+//! compatible with the project's nightly-first ethos.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use pjson_rs_domain::value_objects::SessionId;
+
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+use crate::compression::zstd::ZstdDictionary;
+
+use crate::Result;
+
+/// Heap-allocated future returned by [`DictionaryStore`] methods.
+///
+/// Using `Pin<Box<dyn Future + Send + '_>>` instead of `async_trait` keeps the
+/// dependency tree clean. The lifetime `'a` ties the future to the store borrow.
+pub type DictionaryFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + Send + 'a>>;
+
+/// Port for resolving and accumulating per-session zstd dictionaries.
+///
+/// Implementations must be `Send + Sync` so they can be shared behind
+/// `Arc<dyn DictionaryStore>` across Tokio tasks.
+///
+/// The trait methods are gated on `#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]`
+/// so the trait itself compiles when the feature is disabled (the `dictionary_store`
+/// field on `PjsAppState` still exists, it just exposes no callable methods).
+///
+/// # Contract
+///
+/// - `get_dictionary` returns `Ok(None)` until training completes.
+/// - `train_if_ready` accumulates samples and fires training exactly once when
+///   the configured threshold is reached. Subsequent calls are no-ops.
+pub trait DictionaryStore: Send + Sync {
+    /// Returns the trained dictionary for `session_id`.
+    ///
+    /// Returns `Ok(None)` when training has not yet completed (fewer than the
+    /// configured number of samples or the session is unknown).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use std::sync::Arc;
+    /// use pjson_rs::domain::ports::dictionary_store::{DictionaryStore, NoopDictionaryStore};
+    /// use pjson_rs_domain::value_objects::SessionId;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let store = NoopDictionaryStore;
+    /// let sid = SessionId::new();
+    /// let result = store.get_dictionary(sid).await.unwrap();
+    /// assert!(result.is_none(), "Noop store always returns None");
+    /// # });
+    /// # }
+    /// ```
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    fn get_dictionary<'a>(
+        &'a self,
+        session_id: SessionId,
+    ) -> DictionaryFuture<'a, Option<Arc<ZstdDictionary>>>;
+
+    /// Append `sample` to the training corpus for `session_id`.
+    ///
+    /// When the corpus reaches the configured threshold, training fires exactly
+    /// once (race-free). Subsequent calls after training are no-ops.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use std::sync::Arc;
+    /// use pjson_rs::domain::ports::dictionary_store::{DictionaryStore, NoopDictionaryStore};
+    /// use pjson_rs_domain::value_objects::SessionId;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let store = NoopDictionaryStore;
+    /// let sid = SessionId::new();
+    /// // No-op: always succeeds without training.
+    /// store.train_if_ready(sid, b"sample".to_vec()).await.unwrap();
+    /// # });
+    /// # }
+    /// ```
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    fn train_if_ready<'a>(
+        &'a self,
+        session_id: SessionId,
+        sample: Vec<u8>,
+    ) -> DictionaryFuture<'a, ()>;
+
+    // TODO(#144 follow-up): add remove(SessionId) for session-end eviction.
+}
+
+/// No-op [`DictionaryStore`] that always returns `Ok(None)`.
+///
+/// Used by `PjsAppState::new` so the existing three-argument constructor stays
+/// wire-compatible. Callers that need the dictionary endpoint must upgrade to
+/// `PjsAppState::with_dictionary_store(...)` with a concrete implementation.
+///
+/// # Examples
+///
+/// ```rust
+/// use pjson_rs::domain::ports::dictionary_store::NoopDictionaryStore;
+/// let store = NoopDictionaryStore;
+/// // NoopDictionaryStore is Send + Sync, so it can be wrapped in Arc.
+/// let _: std::sync::Arc<dyn pjson_rs::domain::ports::dictionary_store::DictionaryStore> =
+///     std::sync::Arc::new(store);
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct NoopDictionaryStore;
+
+impl DictionaryStore for NoopDictionaryStore {
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    fn get_dictionary<'a>(
+        &'a self,
+        _: SessionId,
+    ) -> DictionaryFuture<'a, Option<Arc<ZstdDictionary>>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    fn train_if_ready<'a>(&'a self, _: SessionId, _: Vec<u8>) -> DictionaryFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn test_noop_get_dictionary_returns_none() {
+        let store = NoopDictionaryStore;
+        let sid = SessionId::new();
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn test_noop_train_if_ready_is_ok() {
+        let store = NoopDictionaryStore;
+        let sid = SessionId::new();
+        let result = store.train_if_ready(sid, b"sample data".to_vec()).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_noop_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<NoopDictionaryStore>();
+    }
+}

--- a/crates/pjs-core/src/domain/ports/mod.rs
+++ b/crates/pjs-core/src/domain/ports/mod.rs
@@ -6,9 +6,13 @@
 //! This module implements the Ports and Adapters pattern (Hexagonal Architecture)
 //! by defining abstract interfaces that decouple the domain from infrastructure concerns.
 
+pub mod dictionary_store;
 pub mod gat;
 pub mod repositories;
 pub mod writer;
+
+// Dictionary store port
+pub use dictionary_store::{DictionaryFuture, DictionaryStore, NoopDictionaryStore};
 
 // GAT traits (canonical interfaces)
 pub use gat::*;

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -31,7 +31,10 @@ use crate::{
     },
     domain::{
         aggregates::stream_session::{SessionConfig, SessionHealth},
-        ports::{EventPublisherGat, StreamRepositoryGat, StreamStoreGat},
+        ports::{
+            DictionaryStore, EventPublisherGat, NoopDictionaryStore, StreamRepositoryGat,
+            StreamStoreGat,
+        },
         value_objects::{Priority, SessionId, StreamId},
     },
     infrastructure::http::middleware::{RateLimitMiddleware, security_middleware},
@@ -128,7 +131,10 @@ fn build_cors_layer(config: &HttpServerConfig) -> Result<CorsLayer, PjsError> {
     Ok(layer)
 }
 
-/// Axum application state with PJS GAT-based handlers
+/// Axum application state with PJS GAT-based handlers.
+///
+/// The `dictionary_store` field is `pub(crate)` so the dictionary handler can
+/// access it without exposing it as a public API.
 pub struct PjsAppState<R, P, S>
 where
     R: StreamRepositoryGat + Send + Sync + 'static,
@@ -139,6 +145,7 @@ where
     session_query_handler: Arc<SessionQueryHandler<R>>,
     stream_query_handler: Arc<StreamQueryHandler<R, S>>,
     system_handler: Arc<SystemQueryHandler<R>>,
+    pub(crate) dictionary_store: Arc<dyn DictionaryStore>,
 }
 
 impl<R, P, S> Clone for PjsAppState<R, P, S>
@@ -153,6 +160,7 @@ where
             session_query_handler: self.session_query_handler.clone(),
             stream_query_handler: self.stream_query_handler.clone(),
             system_handler: self.system_handler.clone(),
+            dictionary_store: self.dictionary_store.clone(),
         }
     }
 }
@@ -163,9 +171,32 @@ where
     P: EventPublisherGat + Send + Sync + 'static,
     S: StreamStoreGat + Send + Sync + 'static,
 {
-    /// Create a new application state, recording the current instant as the
-    /// process start time for uptime reporting.
+    /// Create a new application state with default [`NoopDictionaryStore`].
+    ///
+    /// The `/pjs/sessions/{id}/dictionary` endpoint will return 404 until
+    /// you upgrade to [`PjsAppState::with_dictionary_store`] with a concrete
+    /// implementation such as [`crate::infrastructure::repositories::InMemoryDictionaryStore`].
+    ///
+    /// Records the current instant as the process start time for uptime reporting.
     pub fn new(repository: Arc<R>, event_publisher: Arc<P>, stream_store: Arc<S>) -> Self {
+        Self::with_dictionary_store(
+            repository,
+            event_publisher,
+            stream_store,
+            Arc::new(NoopDictionaryStore),
+        )
+    }
+
+    /// Create a new application state with a custom [`DictionaryStore`].
+    ///
+    /// Pass `Arc::new(InMemoryDictionaryStore::new(...))` to enable end-to-end
+    /// dictionary training and serving.
+    pub fn with_dictionary_store(
+        repository: Arc<R>,
+        event_publisher: Arc<P>,
+        stream_store: Arc<S>,
+        dictionary_store: Arc<dyn DictionaryStore>,
+    ) -> Self {
         let started_at = Instant::now();
         Self {
             command_handler: Arc::new(SessionCommandHandler::new(
@@ -178,6 +209,7 @@ where
                 stream_store,
             )),
             system_handler: Arc::new(SystemQueryHandler::with_start_time(repository, started_at)),
+            dictionary_store,
         }
     }
 }
@@ -440,7 +472,7 @@ where
     P: EventPublisherGat + Send + Sync + 'static,
     S: StreamStoreGat + Send + Sync + 'static,
 {
-    Router::new()
+    let router = Router::new()
         .route("/pjs/sessions", post(create_session::<R, P, S>))
         .route("/pjs/sessions/{session_id}", get(get_session::<R, P, S>))
         .route(
@@ -469,7 +501,15 @@ where
         )
         .route("/pjs/sessions/search", get(search_sessions::<R, P, S>))
         .route("/pjs/sessions", get(list_sessions::<R, P, S>))
-        .route("/pjs/stats", get(get_system_stats::<R, P, S>))
+        .route("/pjs/stats", get(get_system_stats::<R, P, S>));
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    let router = router.route(
+        "/pjs/sessions/{session_id}/dictionary",
+        get(crate::infrastructure::http::dictionary::get_session_dictionary::<R, P, S>),
+    );
+
+    router
 }
 
 /// Apply the cross-cutting middleware stack shared by all router variants.

--- a/crates/pjs-core/src/infrastructure/http/dictionary.rs
+++ b/crates/pjs-core/src/infrastructure/http/dictionary.rs
@@ -1,0 +1,370 @@
+//! HTTP handler for serving trained zstd dictionaries.
+//!
+//! The endpoint is placed inside `protected_routes()` so it inherits the
+//! auth and rate-limit layers applied by the router factories in
+//! [`crate::infrastructure::http::axum_adapter`].
+
+use axum::{
+    extract::{Path, State},
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use bytes::Bytes;
+use pjson_rs_domain::value_objects::SessionId;
+
+use crate::{
+    domain::ports::{EventPublisherGat, StreamRepositoryGat, StreamStoreGat},
+    infrastructure::http::axum_adapter::{PjsAppState, PjsError},
+};
+
+/// Serve the trained zstd dictionary for a session.
+///
+/// # Responses
+///
+/// | Status | Condition |
+/// |--------|-----------|
+/// | `200 OK` | Dictionary is trained; body is raw bytes with `Content-Type: application/zstd-dictionary` and `Cache-Control: private, max-age=300`. |
+/// | `404 Not Found` | Session unknown or training not yet complete (fewer than `N_TRAIN` samples). |
+/// | `400 Bad Request` | `session_id` path segment is not a valid session UUID. |
+///
+/// # Caching
+///
+/// `Cache-Control: private, max-age=300` (5 minutes). `immutable` is omitted
+/// intentionally — the session may expire before the cache TTL, and serving a
+/// stale dict to a new session would cause decompression errors.
+pub async fn get_session_dictionary<R, P, S>(
+    Path(session_id): Path<String>,
+    State(state): State<PjsAppState<R, P, S>>,
+) -> Result<Response, PjsError>
+where
+    R: StreamRepositoryGat + Send + Sync + 'static,
+    P: EventPublisherGat + Send + Sync + 'static,
+    S: StreamStoreGat + Send + Sync + 'static,
+{
+    let sid = SessionId::from_string(&session_id)
+        .map_err(|_| PjsError::InvalidSessionId(session_id.clone()))?;
+
+    let dict = state
+        .dictionary_store
+        .get_dictionary(sid)
+        .await
+        .map_err(|e| PjsError::HttpError(e.to_string()))?;
+
+    let Some(dict) = dict else {
+        return Ok((StatusCode::NOT_FOUND, "dictionary not yet trained").into_response());
+    };
+
+    // ZstdDictionary's type invariant guarantees len() <= MAX_DICT_SIZE (112 KiB) —
+    // no additional size check is needed here.
+    //
+    // Bytes::copy_from_slice performs a ~64 KiB memcpy per request (low frequency,
+    // acceptable). The Arc remains in the store; the response body owns its slice.
+    let body = Bytes::copy_from_slice(dict.as_bytes());
+
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/zstd-dictionary"),
+            (header::CACHE_CONTROL, "private, max-age=300"),
+        ],
+        body,
+    )
+        .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::to_bytes, http::Request, routing::get};
+    use chrono::Utc;
+    use std::{collections::HashMap, sync::Arc};
+    use tower::ServiceExt;
+
+    use crate::{
+        compression::zstd::{MAX_DICT_SIZE, N_TRAIN, ZstdDictCompressor},
+        domain::ports::dictionary_store::NoopDictionaryStore,
+        domain::{
+            aggregates::StreamSession,
+            entities::Stream,
+            events::DomainEvent,
+            ports::{
+                EventPublisherGat, Pagination, PriorityDistribution, SessionHealthSnapshot,
+                SessionQueryCriteria, SessionQueryResult, StreamFilter, StreamRepositoryGat,
+                StreamStatistics, StreamStatus, StreamStoreGat,
+            },
+            value_objects::StreamId,
+        },
+        infrastructure::{http::axum_adapter::PjsAppState, repositories::InMemoryDictionaryStore},
+        security::CompressionBombDetector,
+    };
+
+    struct MockRepo(parking_lot::Mutex<HashMap<SessionId, StreamSession>>);
+    impl MockRepo {
+        fn new() -> Self {
+            Self(parking_lot::Mutex::new(HashMap::new()))
+        }
+    }
+
+    impl StreamRepositoryGat for MockRepo {
+        type FindSessionFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<Option<StreamSession>>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+        type SaveSessionFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type RemoveSessionFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type FindActiveSessionsFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<Vec<StreamSession>>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+        type FindSessionsByCriteriaFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<SessionQueryResult>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+        type GetSessionHealthFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<SessionHealthSnapshot>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+        type SessionExistsFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<bool>> + Send + 'a
+        where
+            Self: 'a;
+
+        fn find_session(&self, sid: SessionId) -> Self::FindSessionFuture<'_> {
+            async move { Ok(self.0.lock().get(&sid).cloned()) }
+        }
+        fn save_session(&self, s: StreamSession) -> Self::SaveSessionFuture<'_> {
+            async move {
+                self.0.lock().insert(s.id(), s);
+                Ok(())
+            }
+        }
+        fn remove_session(&self, sid: SessionId) -> Self::RemoveSessionFuture<'_> {
+            async move {
+                self.0.lock().remove(&sid);
+                Ok(())
+            }
+        }
+        fn find_active_sessions(&self) -> Self::FindActiveSessionsFuture<'_> {
+            async move { Ok(self.0.lock().values().cloned().collect()) }
+        }
+        fn find_sessions_by_criteria(
+            &self,
+            _: SessionQueryCriteria,
+            p: Pagination,
+        ) -> Self::FindSessionsByCriteriaFuture<'_> {
+            async move {
+                let all: Vec<_> = self.0.lock().values().cloned().collect();
+                let total = all.len();
+                let page: Vec<_> = all.into_iter().skip(p.offset).take(p.limit).collect();
+                let has_more = p.offset + page.len() < total;
+                Ok(SessionQueryResult {
+                    sessions: page,
+                    total_count: total,
+                    has_more,
+                    query_duration_ms: 0,
+                    scan_limit_reached: false,
+                })
+            }
+        }
+        fn get_session_health(&self, session_id: SessionId) -> Self::GetSessionHealthFuture<'_> {
+            async move {
+                Ok(SessionHealthSnapshot {
+                    session_id,
+                    is_healthy: true,
+                    active_streams: 0,
+                    total_frames: 0,
+                    last_activity: Utc::now(),
+                    error_rate: 0.0,
+                    metrics: HashMap::new(),
+                })
+            }
+        }
+        fn session_exists(&self, sid: SessionId) -> Self::SessionExistsFuture<'_> {
+            async move { Ok(self.0.lock().contains_key(&sid)) }
+        }
+    }
+
+    struct MockPublisher;
+    impl EventPublisherGat for MockPublisher {
+        type PublishFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type PublishBatchFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+
+        fn publish(&self, _: DomainEvent) -> Self::PublishFuture<'_> {
+            async move { Ok(()) }
+        }
+        fn publish_batch(&self, _: Vec<DomainEvent>) -> Self::PublishBatchFuture<'_> {
+            async move { Ok(()) }
+        }
+    }
+
+    struct MockStore;
+    impl StreamStoreGat for MockStore {
+        type StoreStreamFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type GetStreamFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<Option<Stream>>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+        type DeleteStreamFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type ListStreamsForSessionFuture<'a>
+            =
+            impl std::future::Future<Output = crate::domain::DomainResult<Vec<Stream>>> + Send + 'a
+        where
+            Self: 'a;
+        type FindStreamsBySessionFuture<'a>
+            =
+            impl std::future::Future<Output = crate::domain::DomainResult<Vec<Stream>>> + Send + 'a
+        where
+            Self: 'a;
+        type UpdateStreamStatusFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<()>> + Send + 'a
+        where
+            Self: 'a;
+        type GetStreamStatisticsFuture<'a>
+            = impl std::future::Future<Output = crate::domain::DomainResult<StreamStatistics>>
+            + Send
+            + 'a
+        where
+            Self: 'a;
+
+        fn store_stream(&self, _: Stream) -> Self::StoreStreamFuture<'_> {
+            async move { Ok(()) }
+        }
+        fn get_stream(&self, _: StreamId) -> Self::GetStreamFuture<'_> {
+            async move { Ok(None) }
+        }
+        fn delete_stream(&self, _: StreamId) -> Self::DeleteStreamFuture<'_> {
+            async move { Ok(()) }
+        }
+        fn list_streams_for_session(&self, _: SessionId) -> Self::ListStreamsForSessionFuture<'_> {
+            async move { Ok(vec![]) }
+        }
+        fn find_streams_by_session(
+            &self,
+            _: SessionId,
+            _: StreamFilter,
+        ) -> Self::FindStreamsBySessionFuture<'_> {
+            async move { Ok(vec![]) }
+        }
+        fn update_stream_status(
+            &self,
+            _: StreamId,
+            _: StreamStatus,
+        ) -> Self::UpdateStreamStatusFuture<'_> {
+            async move { Ok(()) }
+        }
+        fn get_stream_statistics(&self, _: StreamId) -> Self::GetStreamStatisticsFuture<'_> {
+            async move {
+                Ok(StreamStatistics {
+                    total_frames: 0,
+                    total_bytes: 0,
+                    priority_distribution: PriorityDistribution::default(),
+                    avg_frame_size: 0.0,
+                    creation_time: Utc::now(),
+                    completion_time: None,
+                    processing_duration: None,
+                })
+            }
+        }
+    }
+
+    fn build_router(
+        dict_store: Arc<dyn crate::domain::ports::dictionary_store::DictionaryStore>,
+    ) -> Router {
+        let state = PjsAppState::<MockRepo, MockPublisher, MockStore>::with_dictionary_store(
+            Arc::new(MockRepo::new()),
+            Arc::new(MockPublisher),
+            Arc::new(MockStore),
+            dict_store,
+        );
+        Router::new()
+            .route(
+                "/pjs/sessions/{session_id}/dictionary",
+                get(get_session_dictionary::<MockRepo, MockPublisher, MockStore>),
+            )
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn test_dictionary_endpoint_404_when_no_dict() {
+        let router = build_router(Arc::new(NoopDictionaryStore));
+        let sid = SessionId::new();
+        let req = Request::builder()
+            .uri(format!("/pjs/sessions/{sid}/dictionary"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_dictionary_endpoint_200_after_register() {
+        let store = Arc::new(InMemoryDictionaryStore::new(
+            Arc::new(CompressionBombDetector::default()),
+            MAX_DICT_SIZE,
+        ));
+        let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+            .map(|i| format!(r#"{{"n":{i},"v":"x"}}"#).into_bytes())
+            .collect();
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+        let sid = SessionId::new();
+        store.register(sid, dict).unwrap();
+
+        let router = build_router(store);
+        let req = Request::builder()
+            .uri(format!("/pjs/sessions/{sid}/dictionary"))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/zstd-dictionary"
+        );
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "private, max-age=300"
+        );
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert!(!body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dictionary_endpoint_invalid_session_id_returns_400() {
+        let router = build_router(Arc::new(NoopDictionaryStore));
+        let req = Request::builder()
+            .uri("/pjs/sessions/not-a-valid-uuid/dictionary")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/pjs-core/src/infrastructure/http/mod.rs
+++ b/crates/pjs-core/src/infrastructure/http/mod.rs
@@ -4,6 +4,12 @@
 pub mod auth;
 pub mod axum_adapter;
 pub mod axum_extension;
+#[cfg(all(
+    feature = "http-server",
+    feature = "compression",
+    not(target_arch = "wasm32")
+))]
+pub mod dictionary;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod middleware;

--- a/crates/pjs-core/src/infrastructure/repositories/dictionary_store.rs
+++ b/crates/pjs-core/src/infrastructure/repositories/dictionary_store.rs
@@ -1,0 +1,419 @@
+//! In-memory [`DictionaryStore`] implementation with race-free per-session training.
+//!
+//! Available only when `feature = "compression"` is enabled and the target is
+//! not `wasm32`.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use pjson_rs_domain::value_objects::SessionId;
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::{
+    Error, Result,
+    compression::zstd::{MAX_DICT_SIZE, N_TRAIN, ZstdDictCompressor, ZstdDictionary},
+    domain::ports::dictionary_store::{DictionaryFuture, DictionaryStore},
+    security::CompressionBombDetector,
+};
+
+/// Per-session state for corpus accumulation and one-time training.
+struct SessionDictState {
+    /// Training corpus. Capped at `N_TRAIN` entries; the mutex is held only
+    /// during the push and snapshot — it is never held across `spawn_blocking`.
+    corpus: Mutex<Vec<Vec<u8>>>,
+    /// Training result. `OnceCell::get_or_try_init` guarantees that the closure
+    /// runs at most once even when many tasks cross the threshold concurrently.
+    dict: OnceCell<Arc<ZstdDictionary>>,
+}
+
+/// In-memory [`DictionaryStore`] that accumulates training samples per session
+/// and fires a one-time background training task when the corpus is full.
+///
+/// Use [`InMemoryDictionaryStore::new`] and supply it to
+/// `PjsAppState::with_dictionary_store(...)` to enable the dictionary endpoint.
+///
+/// # Session lifecycle
+///
+/// State grows unbounded until the process restarts. Eviction (`remove`) is
+/// deferred to a follow-up (see TODO).
+///
+/// # Concurrency
+///
+/// - A [`DashMap`] provides lock-free shard-level access for per-session state lookup.
+/// - `OnceCell::get_or_try_init` serialises training: only one closure runs to
+///   completion regardless of how many tasks cross the `N_TRAIN` threshold.
+/// - `spawn_blocking` offloads CPU-bound libzstd work off the Tokio runtime thread pool.
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+/// # {
+/// use std::sync::Arc;
+/// use pjson_rs::infrastructure::repositories::InMemoryDictionaryStore;
+/// use pjson_rs::security::CompressionBombDetector;
+///
+/// let store = InMemoryDictionaryStore::new(
+///     Arc::new(CompressionBombDetector::default()),
+///     64 * 1024, // 64 KiB target dictionary size
+/// );
+/// # }
+/// ```
+pub struct InMemoryDictionaryStore {
+    sessions: DashMap<SessionId, Arc<SessionDictState>>,
+    bomb_detector: Arc<CompressionBombDetector>,
+    /// Target dictionary size clamped to `MAX_DICT_SIZE` at construction.
+    target_dict_size: usize,
+}
+
+impl InMemoryDictionaryStore {
+    /// Create a new store.
+    ///
+    /// `target_dict_size` is **clamped** to [`MAX_DICT_SIZE`] (112 KiB). A good
+    /// general default is 64 KiB — it covers most JSON schemas while keeping
+    /// per-session RSS acceptable.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use std::sync::Arc;
+    /// use pjson_rs::infrastructure::repositories::InMemoryDictionaryStore;
+    /// use pjson_rs::security::CompressionBombDetector;
+    ///
+    /// let store = InMemoryDictionaryStore::new(
+    ///     Arc::new(CompressionBombDetector::default()),
+    ///     64 * 1024,
+    /// );
+    /// # }
+    /// ```
+    pub fn new(bomb_detector: Arc<CompressionBombDetector>, target_dict_size: usize) -> Self {
+        Self {
+            sessions: DashMap::new(),
+            bomb_detector,
+            target_dict_size: target_dict_size.min(MAX_DICT_SIZE),
+        }
+    }
+
+    /// Register a pre-trained dictionary for `session_id`.
+    ///
+    /// The bomb detector validates the dictionary's byte count against the
+    /// configured `max_compressed_size` budget — the same gate used for
+    /// compressed frame payloads. This reuse is intentional: the check is a
+    /// "size budget" guard, not a semantic decompression check.
+    ///
+    /// **First-write-wins:** if a dictionary is already registered (or training
+    /// already completed via [`DictionaryStore::train_if_ready`]), the call
+    /// silently returns `Ok(())`. This avoids a TOCTOU race while keeping the
+    /// API simple. Operators calling `register` twice will not learn that the
+    /// second write was a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CompressionError`] if the bomb detector rejects `dict.len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    /// # {
+    /// use std::sync::Arc;
+    /// use pjson_rs::infrastructure::repositories::{InMemoryDictionaryStore};
+    /// use pjson_rs::compression::zstd::{ZstdDictCompressor, MAX_DICT_SIZE, N_TRAIN};
+    /// use pjson_rs::security::CompressionBombDetector;
+    /// use pjson_rs_domain::value_objects::SessionId;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let store = InMemoryDictionaryStore::new(
+    ///     Arc::new(CompressionBombDetector::default()),
+    ///     MAX_DICT_SIZE,
+    /// );
+    /// let samples: Vec<Vec<u8>> = (0..N_TRAIN)
+    ///     .map(|i| format!("{{\"n\":{i}}}").into_bytes())
+    ///     .collect();
+    /// let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+    /// let sid = SessionId::new();
+    /// store.register(sid, dict).unwrap();
+    /// # });
+    /// # }
+    /// ```
+    pub fn register(&self, session_id: SessionId, dict: ZstdDictionary) -> Result<()> {
+        // Reuses `validate_pre_decompression` as a size-budget gate. The function
+        // name refers to its primary call site (pre-decompression checks), but the
+        // underlying logic — "reject if byte count exceeds the configured cap" — is
+        // equally applicable to dictionary blobs.
+        self.bomb_detector
+            .validate_pre_decompression(dict.len())
+            .map_err(|e| {
+                Error::CompressionError(format!("dictionary rejected by bomb detector: {e}"))
+            })?;
+
+        let state = self
+            .sessions
+            .entry(session_id)
+            .or_insert_with(|| {
+                Arc::new(SessionDictState {
+                    corpus: Mutex::new(Vec::new()),
+                    dict: OnceCell::new(),
+                })
+            })
+            .clone();
+
+        // First-write-wins: silently ignore if already set.
+        let _ = state.dict.set(Arc::new(dict));
+        Ok(())
+    }
+
+    /// Return or initialise the per-session state entry.
+    fn session_state(&self, session_id: SessionId) -> Arc<SessionDictState> {
+        self.sessions
+            .entry(session_id)
+            .or_insert_with(|| {
+                Arc::new(SessionDictState {
+                    corpus: Mutex::new(Vec::new()),
+                    dict: OnceCell::new(),
+                })
+            })
+            .clone()
+    }
+}
+
+impl DictionaryStore for InMemoryDictionaryStore {
+    fn get_dictionary<'a>(
+        &'a self,
+        session_id: SessionId,
+    ) -> DictionaryFuture<'a, Option<Arc<ZstdDictionary>>> {
+        Box::pin(async move {
+            Ok(self
+                .sessions
+                .get(&session_id)
+                .and_then(|s| s.dict.get().cloned()))
+        })
+    }
+
+    fn train_if_ready<'a>(
+        &'a self,
+        session_id: SessionId,
+        sample: Vec<u8>,
+    ) -> DictionaryFuture<'a, ()> {
+        Box::pin(async move {
+            // TODO(#144 follow-up): per-sample size cap to bound corpus RSS.
+            let state = self.session_state(session_id);
+
+            // Fast path: dictionary already trained (no lock acquisition needed).
+            if state.dict.initialized() {
+                return Ok(());
+            }
+
+            // Append sample and snapshot when threshold reached.
+            // The mutex is released before any async/blocking work.
+            let snapshot = {
+                let mut guard = state.corpus.lock().await;
+                if guard.len() < N_TRAIN {
+                    guard.push(sample);
+                }
+                if guard.len() < N_TRAIN {
+                    return Ok(());
+                }
+                guard.clone()
+            };
+
+            let target = self.target_dict_size;
+            let bomb_detector = self.bomb_detector.clone();
+
+            // `get_or_try_init` runs the closure at most once even when many tasks
+            // cross the threshold concurrently. On failure (transient libzstd error)
+            // the cell is NOT poisoned — the next crossing will retry.
+            let _ = state
+                .dict
+                .get_or_try_init(|| async move {
+                    let dict = tokio::task::spawn_blocking(move || {
+                        ZstdDictCompressor::train(&snapshot, target)
+                    })
+                    .await
+                    .map_err(|e| {
+                        Error::CompressionError(format!("zstd: train join error: {e}"))
+                    })??;
+
+                    // Symmetric bomb-detector check after training, mirroring `register()`.
+                    // Catches the case where CompressionBombConfig is tuned tighter than
+                    // MAX_DICT_SIZE — the trained dict could legitimately exceed the
+                    // deployment's configured budget even though the type invariant holds.
+                    bomb_detector
+                        .validate_pre_decompression(dict.len())
+                        .map_err(|e| {
+                            Error::CompressionError(format!(
+                                "trained dict rejected by bomb detector: {e}"
+                            ))
+                        })?;
+
+                    Ok::<_, Error>(Arc::new(dict))
+                })
+                .await?;
+
+            Ok(())
+        })
+    }
+}
+
+// TODO(#144 follow-up): persistent backend (sled/sqlite) when in-memory store proves insufficient.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pjson_rs_domain::value_objects::SessionId;
+
+    fn make_store() -> InMemoryDictionaryStore {
+        InMemoryDictionaryStore::new(Arc::new(CompressionBombDetector::default()), 64 * 1024)
+    }
+
+    fn make_samples(count: usize) -> Vec<Vec<u8>> {
+        (0..count)
+            .map(|i| format!(r#"{{"id":{i},"name":"item","value":{}}}"#, i * 10).into_bytes())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn test_get_dictionary_returns_none_before_training() {
+        let store = make_store();
+        let sid = SessionId::new();
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_train_if_ready_below_threshold_stays_none() {
+        let store = make_store();
+        let sid = SessionId::new();
+
+        for i in 0..(N_TRAIN - 1) {
+            let sample = format!(r#"{{"i":{i}}}"#).into_bytes();
+            store.train_if_ready(sid, sample).await.unwrap();
+        }
+
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(
+            result.is_none(),
+            "should still be None before N_TRAIN samples"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_train_if_ready_fires_after_threshold() {
+        let store = make_store();
+        let sid = SessionId::new();
+        let samples = make_samples(N_TRAIN);
+
+        for sample in samples {
+            store.train_if_ready(sid, sample).await.unwrap();
+        }
+
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(
+            result.is_some(),
+            "dictionary should be Some after N_TRAIN samples"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_then_get_returns_dict() {
+        let store = make_store();
+        let sid = SessionId::new();
+        let samples = make_samples(N_TRAIN);
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+
+        store.register(sid, dict).unwrap();
+
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_train_if_ready_produces_exactly_one_dict() {
+        use futures::future::try_join_all;
+
+        let store = Arc::new(make_store());
+        let sid = SessionId::new();
+        let samples = make_samples(N_TRAIN * 2); // more than enough
+
+        let futs: Vec<_> = samples
+            .into_iter()
+            .map(|sample| {
+                let store = store.clone();
+                tokio::spawn(async move { store.train_if_ready(sid, sample).await })
+            })
+            .collect();
+
+        // All tasks must complete without panicking or erroring.
+        let results = try_join_all(futs).await.unwrap();
+        for r in results {
+            r.unwrap();
+        }
+
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(result.is_some(), "exactly one dictionary should be trained");
+    }
+
+    #[tokio::test]
+    async fn test_train_if_ready_bomb_detector_rejects_trained_dict() {
+        use crate::security::CompressionBombConfig;
+
+        // A budget so tight that any real trained dictionary will exceed it.
+        let config = CompressionBombConfig {
+            max_compressed_size: 100,
+            ..Default::default()
+        };
+        let store = InMemoryDictionaryStore::new(
+            Arc::new(CompressionBombDetector::new(config)),
+            MAX_DICT_SIZE,
+        );
+        let sid = SessionId::new();
+        let samples = make_samples(N_TRAIN);
+
+        // Feed all samples. The call that crosses the N_TRAIN threshold triggers
+        // training and then runs the bomb-detector check; that check fails, so
+        // get_or_try_init propagates the error back through train_if_ready via `?`.
+        // All preceding calls (below the threshold) return Ok(()).
+        let mut training_error_seen = false;
+        for sample in samples {
+            let result = store.train_if_ready(sid, sample).await;
+            if result.is_err() {
+                training_error_seen = true;
+                // Only the threshold-crossing call should fail.
+                break;
+            }
+        }
+        assert!(
+            training_error_seen,
+            "expected bomb detector to reject the trained dict"
+        );
+
+        // The dictionary must not be accessible because the bomb detector rejected it.
+        let result = store.get_dictionary(sid).await.unwrap();
+        assert!(
+            result.is_none(),
+            "bomb detector should have prevented dict from being stored"
+        );
+    }
+
+    #[test]
+    fn test_register_rejects_oversized_dict_via_bomb_detector() {
+        use crate::security::CompressionBombConfig;
+
+        let config = CompressionBombConfig {
+            max_compressed_size: 10, // tinier than any real dict
+            ..Default::default()
+        };
+        let store = InMemoryDictionaryStore::new(
+            Arc::new(CompressionBombDetector::new(config)),
+            MAX_DICT_SIZE,
+        );
+        let sid = SessionId::new();
+        let samples = make_samples(N_TRAIN);
+        let dict = ZstdDictCompressor::train(&samples, MAX_DICT_SIZE).unwrap();
+
+        let result = store.register(sid, dict);
+        assert!(result.is_err(), "bomb detector must reject oversized dict");
+    }
+}

--- a/crates/pjs-core/src/infrastructure/repositories/mod.rs
+++ b/crates/pjs-core/src/infrastructure/repositories/mod.rs
@@ -1,5 +1,9 @@
 //! Repository implementations for data persistence
 //!
-//! Contains implementations for storing and retrieving PJS data
+//! Contains implementations for storing and retrieving PJS data.
 
-// Re-exports will be added as needed
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+pub mod dictionary_store;
+
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+pub use dictionary_store::InMemoryDictionaryStore;

--- a/crates/pjs-demo/src/servers/interactive_demo.rs
+++ b/crates/pjs-demo/src/servers/interactive_demo.rs
@@ -15,14 +15,15 @@ use pjs_demo::{
     data::{DatasetSize, DatasetType, generate_dataset, generate_metadata},
     utils::{NetworkType, PerfTimer, simulate_network_latency},
 };
-// TODO: Re-enable streaming imports when infrastructure is stable
-// use pjson_rs::{
-//     StreamProcessor, StreamConfig, StreamFrame, Priority,
-//     StreamingCompressor, SchemaCompressor, CompressionStrategy,
-// };
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+use pjson_rs::infrastructure::repositories::InMemoryDictionaryStore;
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+use pjson_rs::security::CompressionBombDetector;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+use std::sync::Arc;
 use tokio::time::sleep;
 use tracing::info;
 
@@ -368,6 +369,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // WebSocket support will be added later
     };
 
+    // Wire the in-memory dictionary store so that the library's
+    // `GET /pjs/sessions/{id}/dictionary` endpoint is reachable end-to-end once
+    // N_TRAIN frame samples have been accumulated for a session.
+    //
+    // Example wiring (not mounted here because this demo uses a custom router):
+    //   let dict_store = Arc::new(InMemoryDictionaryStore::new(
+    //       Arc::new(CompressionBombDetector::default()),
+    //       64 * 1024,
+    //   ));
+    //   let pjs_state = PjsAppState::with_dictionary_store(repo, publisher, store, dict_store);
+    //   let pjs_router = create_pjs_router::<R, P, S>().with_state(pjs_state);
+    //   let app = Router::new().merge(pjs_router).merge(demo_router);
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    let _dict_store = Arc::new(InMemoryDictionaryStore::new(
+        Arc::new(CompressionBombDetector::default()),
+        64 * 1024,
+    ));
+
     // Build router
     let app = Router::new()
         .route("/", get(demo_page))
@@ -388,12 +407,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("📱 Web Interface:");
     println!("   http://{}:{}/ - Interactive Demo", args.host, args.port);
     println!();
-    println!("🔗 API Endpoints:");
+    println!("API Endpoints:");
     println!("   GET  /traditional?dataset_type=ecommerce&dataset_size=medium&network_type=wifi");
     println!("   GET  /pjs-streaming?dataset_type=social&dataset_size=large&network_type=4g");
     println!("   GET  /performance?dataset_type=analytics&dataset_size=small&network_type=fiber");
     println!("   GET  /api/info - API documentation");
     println!("   WS   /ws - WebSocket streaming");
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    println!("   GET  /pjs/sessions/{{session_id}}/dictionary - zstd dict (via InMemoryDictionaryStore)");
     println!();
     println!("🎯 Dataset Types: ecommerce, social, analytics, realtime");
     println!("📊 Dataset Sizes: small, medium, large, huge");


### PR DESCRIPTION
## Summary

- Adds `ZstdDictionary` newtype with 112 KiB type invariant and zstd magic-byte validation (`compression/zstd.rs`)
- Adds `ZstdDictCompressor` — stateless trainer/compressor/decompressor for dict-mode zstd
- Extends `ByteCodec` with `ZstdDict(Arc<ZstdDictionary>)` variant; decompression routed through `CompressionBombProtector` via streaming decoder
- Adds `DictionaryStore` port + `InMemoryDictionaryStore` (OnceCell per session, race-free training)
- Adds `GET /pjs/sessions/{id}/dictionary` HTTP endpoint (mounted under `protected_routes()`)

## Breaking change

`ByteCodec` loses `Copy` because `ZstdDict(Arc<ZstdDictionary>)` is not `Copy`. Call sites that move a `ByteCodec` value must now call `.clone()` or borrow.

## Known limitations (tracked as follow-ups)

- Dictionary eviction on session end (`DictionaryStore::remove`) — memory grows unbounded with many sessions
- Per-sample size cap in `train_if_ready` — corpus size uncapped before training fires
- Auto-training hook into the frame-write path is not wired; callers use `register()` explicitly

## Test plan

- [x] 999 unit tests pass (`cargo nextest run --workspace --all-features --lib --bins`)
- [x] 23 doc-tests pass (`cargo test --doc --all-features -p pjson-rs`)
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Empty payload roundtrip via `ByteCodec::ZstdDict`
- [x] Wrong-dictionary decompression returns error
- [x] Bomb detector rejects oversized trained dictionary
- [x] HTTP 200/404 and content-type verified in handler tests

Closes #144