### PR TITLE
docs(pjson-rs): fix broken intra-doc links and unclosed HTML tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `cargo doc --deny rustdoc::broken_intra_doc_links` now passes: replaced `[ApiKeyAuthLayer]` with `[super::ApiKeyAuthLayer]` in `JwtAuthLayer` doc, dropped the link to private `build_cors_layer` in `create_pjs_router_with_config` doc, and wrapped `Id<T>` and `Box<dyn Trait>` in code spans in `id_dto.rs` and `gat.rs` (closes #225)
+
 ## [0.5.2] - 2026-04-29
 
 ### Security

--- a/crates/pjs-core/src/application/dto/id_dto.rs
+++ b/crates/pjs-core/src/application/dto/id_dto.rs
@@ -1,6 +1,6 @@
 //! Generic ID Data Transfer Object for serialization
 //!
-//! Handles serialization/deserialization of Id<T> domain objects
+//! Handles serialization/deserialization of `Id<T>` domain objects
 //! while keeping domain layer clean of serialization concerns.
 
 use crate::application::dto::priority_dto::{FromDto, ToDto};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use uuid::Uuid;
 
-/// Generic serializable representation of Id<T> domain object.
+/// Generic serializable representation of `Id<T>` domain object.
 ///
 /// The phantom marker is skipped during serialization, resulting in
 /// a transparent UUID representation in JSON.

--- a/crates/pjs-core/src/domain/ports/gat.rs
+++ b/crates/pjs-core/src/domain/ports/gat.rs
@@ -401,7 +401,7 @@ gat_port! {
 /// Zero-cost writer factory with GAT futures
 ///
 /// Factory for creating frame sink and writer instances.
-/// Note: Returns associated types instead of Box<dyn Trait> for zero-cost.
+/// Note: Returns associated types instead of `Box<dyn Trait>` for zero-cost.
 pub trait WriterFactoryGat: Send + Sync {
     /// Associated type for stream writer implementation
     type StreamWriter: FrameSinkGat + Send;

--- a/crates/pjs-core/src/infrastructure/http/auth.rs
+++ b/crates/pjs-core/src/infrastructure/http/auth.rs
@@ -380,7 +380,7 @@ mod inner {
         /// in a separate extractor layer.
         ///
         /// `OPTIONS` requests are passed through without authentication (same as
-        /// [`ApiKeyAuthLayer`]).
+        /// [`super::ApiKeyAuthLayer`]).
         pub struct JwtAuthLayer<C> {
             inner: Arc<JwtState>,
             _claims: PhantomData<fn() -> C>,

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -292,8 +292,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`PjsError::HttpError`] if `config` contains invalid CORS origins
-/// (see [`build_cors_layer`] for the full list of failure conditions).
+/// Returns [`PjsError::HttpError`] if `config` contains invalid CORS origins —
+/// specifically, when `allowed_origins` mixes `"*"` with explicit origins, or
+/// any origin string fails to parse as a valid `HeaderValue`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

- Restore the `cargo doc --deny rustdoc::broken_intra_doc_links` gate by fixing the 4 issues introduced after #213
- Qualify the cross-`mod` link to `ApiKeyAuthLayer`, drop the link to the private `build_cors_layer`, and wrap `Id<T>` / `Box<dyn Trait>` in code spans

## Changes

- `crates/pjs-core/src/infrastructure/http/auth.rs:383` — `[ApiKeyAuthLayer]` → `[super::ApiKeyAuthLayer]` (link is inside `mod inner::jwt`, the type lives in `mod inner`)
- `crates/pjs-core/src/infrastructure/http/axum_adapter.rs:296` — replaced the link to private `build_cors_layer` with an inline description of the failure conditions
- `crates/pjs-core/src/application/dto/id_dto.rs:3,15` — wrapped `Id<T>` in backticks to close the HTML tag
- `crates/pjs-core/src/domain/ports/gat.rs:404` — wrapped `Box<dyn Trait>` in backticks to close the HTML tag
- `CHANGELOG.md` — entry under `[Unreleased]` / `Fixed`

Closes #225

## Test plan

- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjson-rs -p pjson-rs-domain --all-features` exits 0
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1025 passed)
- [x] `cargo test --workspace --doc --all-features`