### PR TITLE
fix(http): wire train_if_ready into frame-ingest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `cargo doc --deny rustdoc::broken_intra_doc_links` now passes: replaced `[ApiKeyAuthLayer]` with `[super::ApiKeyAuthLayer]` in `JwtAuthLayer` doc, dropped the link to private `build_cors_layer` in `create_pjs_router_with_config` doc, and wrapped `Id<T>` and `Box<dyn Trait>` in code spans in `id_dto.rs` and `gat.rs` (closes #225)
+- `GET /pjs/sessions/{session_id}/dictionary` is now reachable end-to-end. `SessionCommandHandler` accepts an `Arc<dyn DictionaryStore>` and feeds each accepted frame's serialized payload into the per-session training corpus from `GenerateFramesCommand` and `BatchGenerateFramesCommand` handlers, so the endpoint flips from `404 Not Found` to `200 OK` once `N_TRAIN` (32) frames have been generated (closes #224).
+
+### Added
+
+- `SessionCommandHandler::with_dictionary_store(repository, event_publisher, dictionary_store)` constructor; the existing `new` constructor defaults to `NoopDictionaryStore` (no behaviour change for callers that do not opt in to dictionary training).
+- Regression tests in `application::handlers::command_handlers::tests::dictionary_wiring` verifying that the handler invokes `train_if_ready` for every accepted frame and that `N_TRAIN` frames produce a usable trained dictionary.
+
+### Changed
+
+- `pjs-demo`: removed the unused `_dict_store` binding and the misleading "GET /pjs/sessions/{session_id}/dictionary" startup banner from `interactive-demo-server` — the demo never mounted the PJS router, so the binding was dead code and the printed endpoint was unreachable from this binary.
 
 ## [0.5.2] - 2026-04-29
 

--- a/crates/pjs-core/src/application/handlers/command_handlers.rs
+++ b/crates/pjs-core/src/application/handlers/command_handlers.rs
@@ -8,14 +8,18 @@ use crate::{
     domain::{
         aggregates::StreamSession,
         entities::Frame,
-        ports::{EventPublisherGat, StreamRepositoryGat},
+        ports::{DictionaryStore, EventPublisherGat, NoopDictionaryStore, StreamRepositoryGat},
         value_objects::{JsonData, SessionId, StreamId},
     },
 };
 use std::sync::Arc;
 
-/// Handler for session management commands
-#[derive(Debug)]
+/// Handler for session management commands.
+///
+/// Holds an optional [`DictionaryStore`] (defaulting to [`NoopDictionaryStore`])
+/// so that frame-generating commands can feed accepted frame payloads into the
+/// per-session training corpus. Without this wiring the
+/// `GET /pjs/sessions/{id}/dictionary` endpoint would be unreachable end-to-end.
 pub struct SessionCommandHandler<R, P>
 where
     R: StreamRepositoryGat + 'static,
@@ -23,6 +27,18 @@ where
 {
     repository: Arc<R>,
     event_publisher: Arc<P>,
+    dictionary_store: Arc<dyn DictionaryStore>,
+}
+
+impl<R, P> std::fmt::Debug for SessionCommandHandler<R, P>
+where
+    R: StreamRepositoryGat + 'static,
+    P: EventPublisherGat + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionCommandHandler")
+            .finish_non_exhaustive()
+    }
 }
 
 impl<R, P> SessionCommandHandler<R, P>
@@ -30,10 +46,45 @@ where
     R: StreamRepositoryGat + 'static,
     P: EventPublisherGat + 'static,
 {
+    /// Create a handler with the no-op [`DictionaryStore`].
+    ///
+    /// The dictionary endpoint will return `404 Not Found` until the handler is
+    /// constructed with [`SessionCommandHandler::with_dictionary_store`] and a
+    /// concrete implementation such as
+    /// [`crate::infrastructure::repositories::InMemoryDictionaryStore`].
     pub fn new(repository: Arc<R>, event_publisher: Arc<P>) -> Self {
+        Self::with_dictionary_store(repository, event_publisher, Arc::new(NoopDictionaryStore))
+    }
+
+    /// Create a handler that feeds accepted frames into `dictionary_store`.
+    pub fn with_dictionary_store(
+        repository: Arc<R>,
+        event_publisher: Arc<P>,
+        dictionary_store: Arc<dyn DictionaryStore>,
+    ) -> Self {
         Self {
             repository,
             event_publisher,
+            dictionary_store,
+        }
+    }
+
+    /// Feed each accepted frame's serialized payload into the per-session
+    /// training corpus.
+    ///
+    /// Errors are intentionally swallowed: training is best-effort and a
+    /// transient failure must not poison the frame-generation response. The
+    /// `OnceCell` inside `InMemoryDictionaryStore` is not poisoned on error
+    /// either, so the next sample will retry.
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    async fn train_from_frames(&self, session_id: SessionId, frames: &[Frame]) {
+        for frame in frames {
+            if let Ok(bytes) = serde_json::to_vec(frame.payload()) {
+                let _ = self
+                    .dictionary_store
+                    .train_if_ready(session_id, bytes)
+                    .await;
+            }
         }
     }
 }
@@ -281,6 +332,12 @@ where
             #[cfg(feature = "metrics")]
             metrics::counter!("pjs_frames_total").increment(frames.len() as u64);
 
+            // Feed accepted frame payloads into the per-session training corpus
+            // so the dictionary endpoint becomes reachable end-to-end.
+            #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+            self.train_from_frames(command.session_id.into(), &frames)
+                .await;
+
             // Save updated session
             self.repository
                 .save_session(session.clone())
@@ -332,6 +389,12 @@ where
             // command handlers — if so, pjs_frames_total underreports throughput.
             #[cfg(feature = "metrics")]
             metrics::counter!("pjs_frames_total").increment(frames.len() as u64);
+
+            // Feed accepted frame payloads into the per-session training corpus
+            // so the dictionary endpoint becomes reachable end-to-end.
+            #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+            self.train_from_frames(command.session_id.into(), &frames)
+                .await;
 
             // Save updated session
             self.repository
@@ -956,5 +1019,131 @@ mod tests {
             result.err().unwrap(),
             ApplicationError::NotFound(_)
         ));
+    }
+
+    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+    mod dictionary_wiring {
+        //! Regression tests for issue #224 — frame-ingest must feed the per-session
+        //! training corpus so that `GET /pjs/sessions/{id}/dictionary` becomes
+        //! reachable end-to-end.
+        use super::*;
+        use crate::{
+            compression::zstd::N_TRAIN,
+            domain::{
+                entities::Frame,
+                ports::{DictionaryFuture, DictionaryStore},
+            },
+            infrastructure::repositories::InMemoryDictionaryStore,
+            security::CompressionBombDetector,
+        };
+        use pjson_rs_domain::value_objects::{JsonData, StreamId};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Counts every `train_if_ready` invocation so a test can verify the
+        /// command handler reaches the dictionary store at all.
+        struct CountingDictionaryStore {
+            inner: InMemoryDictionaryStore,
+            calls: AtomicUsize,
+        }
+
+        impl CountingDictionaryStore {
+            fn new() -> Self {
+                Self {
+                    inner: InMemoryDictionaryStore::new(
+                        Arc::new(CompressionBombDetector::default()),
+                        64 * 1024,
+                    ),
+                    calls: AtomicUsize::new(0),
+                }
+            }
+
+            fn call_count(&self) -> usize {
+                self.calls.load(Ordering::SeqCst)
+            }
+        }
+
+        impl DictionaryStore for CountingDictionaryStore {
+            fn get_dictionary<'a>(
+                &'a self,
+                session_id: SessionId,
+            ) -> DictionaryFuture<'a, Option<Arc<crate::compression::zstd::ZstdDictionary>>>
+            {
+                self.inner.get_dictionary(session_id)
+            }
+
+            fn train_if_ready<'a>(
+                &'a self,
+                session_id: SessionId,
+                sample: Vec<u8>,
+            ) -> DictionaryFuture<'a, ()> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.inner.train_if_ready(session_id, sample)
+            }
+        }
+
+        fn make_patch_frame(stream_id: StreamId, sequence: u64, n: usize) -> Frame {
+            let patch = crate::domain::entities::frame::FramePatch::set(
+                pjson_rs_domain::value_objects::JsonPath::new(format!("$.items[{n}]")).unwrap(),
+                JsonData::Integer(n as i64),
+            );
+            Frame::patch(
+                stream_id,
+                sequence,
+                pjson_rs_domain::value_objects::Priority::HIGH,
+                vec![patch],
+            )
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn test_train_from_frames_records_each_payload() {
+            let store = Arc::new(CountingDictionaryStore::new());
+            let handler = SessionCommandHandler::with_dictionary_store(
+                Arc::new(MockRepository::new()),
+                Arc::new(MockEventPublisher),
+                store.clone(),
+            );
+
+            let session_id = SessionId::new();
+            let stream_id = StreamId::new();
+            let frames: Vec<Frame> = (0..5)
+                .map(|i| make_patch_frame(stream_id, i as u64, i))
+                .collect();
+
+            handler.train_from_frames(session_id, &frames).await;
+
+            assert_eq!(
+                store.call_count(),
+                5,
+                "every accepted frame must feed train_if_ready"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_train_from_frames_fires_dictionary_after_threshold() {
+            let store = Arc::new(InMemoryDictionaryStore::new(
+                Arc::new(CompressionBombDetector::default()),
+                64 * 1024,
+            ));
+            let handler = SessionCommandHandler::with_dictionary_store(
+                Arc::new(MockRepository::new()),
+                Arc::new(MockEventPublisher),
+                store.clone(),
+            );
+
+            let session_id = SessionId::new();
+            let stream_id = StreamId::new();
+            let frames: Vec<Frame> = (0..N_TRAIN)
+                .map(|i| make_patch_frame(stream_id, i as u64, i))
+                .collect();
+
+            handler.train_from_frames(session_id, &frames).await;
+
+            let dict = store.get_dictionary(session_id).await.unwrap();
+            assert!(
+                dict.is_some(),
+                "dictionary must be trained once N_TRAIN frame payloads have been ingested"
+            );
+        }
     }
 }

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -199,9 +199,10 @@ where
     ) -> Self {
         let started_at = Instant::now();
         Self {
-            command_handler: Arc::new(SessionCommandHandler::new(
+            command_handler: Arc::new(SessionCommandHandler::with_dictionary_store(
                 repository.clone(),
                 event_publisher,
+                dictionary_store.clone(),
             )),
             session_query_handler: Arc::new(SessionQueryHandler::new(repository.clone())),
             stream_query_handler: Arc::new(StreamQueryHandler::new(

--- a/crates/pjs-demo/src/servers/interactive_demo.rs
+++ b/crates/pjs-demo/src/servers/interactive_demo.rs
@@ -15,15 +15,9 @@ use pjs_demo::{
     data::{DatasetSize, DatasetType, generate_dataset, generate_metadata},
     utils::{NetworkType, PerfTimer, simulate_network_latency},
 };
-#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
-use pjson_rs::infrastructure::repositories::InMemoryDictionaryStore;
-#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
-use pjson_rs::security::CompressionBombDetector;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{collections::HashMap, net::SocketAddr, time::Duration};
-#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
-use std::sync::Arc;
 use tokio::time::sleep;
 use tracing::info;
 
@@ -369,24 +363,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // WebSocket support will be added later
     };
 
-    // Wire the in-memory dictionary store so that the library's
-    // `GET /pjs/sessions/{id}/dictionary` endpoint is reachable end-to-end once
-    // N_TRAIN frame samples have been accumulated for a session.
-    //
-    // Example wiring (not mounted here because this demo uses a custom router):
-    //   let dict_store = Arc::new(InMemoryDictionaryStore::new(
-    //       Arc::new(CompressionBombDetector::default()),
-    //       64 * 1024,
-    //   ));
-    //   let pjs_state = PjsAppState::with_dictionary_store(repo, publisher, store, dict_store);
-    //   let pjs_router = create_pjs_router::<R, P, S>().with_state(pjs_state);
-    //   let app = Router::new().merge(pjs_router).merge(demo_router);
-    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
-    let _dict_store = Arc::new(InMemoryDictionaryStore::new(
-        Arc::new(CompressionBombDetector::default()),
-        64 * 1024,
-    ));
-
     // Build router
     let app = Router::new()
         .route("/", get(demo_page))
@@ -413,8 +389,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("   GET  /performance?dataset_type=analytics&dataset_size=small&network_type=fiber");
     println!("   GET  /api/info - API documentation");
     println!("   WS   /ws - WebSocket streaming");
-    #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
-    println!("   GET  /pjs/sessions/{{session_id}}/dictionary - zstd dict (via InMemoryDictionaryStore)");
     println!();
     println!("🎯 Dataset Types: ecommerce, social, analytics, realtime");
     println!("📊 Dataset Sizes: small, medium, large, huge");


### PR DESCRIPTION
## Summary

- Wires `DictionaryStore::train_if_ready` into the production frame-ingest path, closing the gap reported in #224 where `GET /pjs/sessions/{session_id}/dictionary` always returned `404 Not Found` regardless of how many frames a client submitted.
- `SessionCommandHandler` now holds an `Arc<dyn DictionaryStore>` (defaulting to `NoopDictionaryStore`); `GenerateFramesCommand` and `BatchGenerateFramesCommand` feed every accepted frame's serialized payload into the per-session corpus.
- `PjsAppState::with_dictionary_store` propagates the store into the handler, so the dictionary endpoint flips to `200 OK` once `N_TRAIN` (32) frames have been ingested for the session.
- `pjs-demo`: dropped the unused `_dict_store` binding and the misleading "GET /pjs/sessions/{session_id}/dictionary" startup banner from `interactive-demo-server` — that binary uses a custom router and never mounted the PJS router.

Closes #224.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1027 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] New regression tests in `application::handlers::command_handlers::tests::dictionary_wiring`:
  - `test_train_from_frames_records_each_payload` — counting dictionary store proves every accepted frame reaches `train_if_ready`.
  - `test_train_from_frames_fires_dictionary_after_threshold` — `N_TRAIN` frame payloads produce a usable trained dictionary.