### PR TITLE
ci: enforce broken-intra-doc-links check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
 
-      - uses: mozilla-actions/sccache-action@v0.0.10
-
       - uses: Swatinem/rust-cache@v2
         with:
           # Share the cache key with the system-allocator build on ubuntu so
@@ -300,13 +298,8 @@ jobs:
 
       - name: Check intra-doc links
         env:
-          RUSTC_WRAPPER: sccache
-          SCCACHE_GHA_ENABLED: "true"
           RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links"
         run: cargo doc --no-deps --all-features -p pjson-rs -p pjson-rs-domain
-
-      - name: Print sccache stats
-        run: sccache --show-stats
 
   # Coverage runs on ubuntu only; does not wait for the cross-platform matrix.
   # Skipped when only JS files changed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,47 @@ jobs:
       - name: Print sccache stats
         run: sccache --show-stats
 
+  # Intra-doc link check.  Enforces the project rule from
+  # `.claude/rules/branching.md`: rustdoc must not emit broken intra-doc links.
+  # Doc generation is OS-independent, so this runs on ubuntu only.
+  docs:
+    name: Doc Links
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [changes, quality]
+    if: |
+      needs.changes.outputs.rust == 'true' ||
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Share the cache key with the system-allocator build on ubuntu so
+          # the compiler cache is warm when this job runs.
+          shared-key: "build-ubuntu-latest-system"
+          save-if: false
+          cache-on-failure: true
+          cache-directories: |
+            ~/.cargo/registry
+            ~/.cargo/git
+
+      - name: Check intra-doc links
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTDOCFLAGS: "--deny rustdoc::broken_intra_doc_links"
+        run: cargo doc --no-deps --all-features -p pjson-rs -p pjson-rs-domain
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+
   # Coverage runs on ubuntu only; does not wait for the cross-platform matrix.
   # Skipped when only JS files changed.
   coverage:
@@ -572,6 +613,7 @@ jobs:
       - build
       - test
       - doctest
+      - docs
       - coverage
       - wasm-build
       - wasm-bundle-size
@@ -595,6 +637,7 @@ jobs:
           check build                     "${{ needs.build.result }}"
           check test                      "${{ needs.test.result }}"
           check doctest                   "${{ needs.doctest.result }}"
+          check docs                      "${{ needs.docs.result }}"
           check coverage                  "${{ needs.coverage.result }}"
           check wasm-build                "${{ needs.wasm-build.result }}"
           check wasm-bundle-size          "${{ needs.wasm-bundle-size.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI job `docs` enforcing `RUSTDOCFLAGS=--deny rustdoc::broken_intra_doc_links` on `cargo doc --no-deps --all-features -p pjson-rs -p pjson-rs-domain`. Wired into the `ci-success` gate so broken intra-doc links now block merges instead of slipping through review (closes #236).
+
 ### Changed
 
 - **BREAKING** `AdaptiveFrameStream::into_stream`, `BatchFrameStream::into_stream`, `PriorityFrameStream::into_stream`, `create_streaming_response`, and `create_streaming_response_with_content_type` now operate on `Vec<u8>` instead of `String`. Threading bytes end-to-end is what makes `AdaptiveFrameStream::with_compression(true)` actually usable — the previous `String` pipeline rejected gzip output (which is binary, not UTF-8) with `StreamError::Io("compressed output is not valid UTF-8")` for every chunk. Callers that need a textual view of an uncompressed frame can decode each payload with `std::str::from_utf8`. Pre-1.0 breaking change; no deprecation cycle (closes #226).


### PR DESCRIPTION
## Summary

- Add a dedicated `docs` job to `.github/workflows/ci.yml` that runs `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p pjson-rs -p pjson-rs-domain` on `ubuntu-latest`.
- Wire it into the `ci-success` aggregator so broken intra-doc links now block merges.
- Rule was previously documented in `.claude/rules/branching.md` as a convention only; this turns it into an enforced gate. PR #212 -> #225 -> PR #227 is the closed precedent of a regression that slipped through review.

Closes #236.

## Test plan

- [x] `fy lint .github/workflows/ci.yml` — 0 errors (warnings are pre-existing, unrelated to the diff).
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p pjson-rs -p pjson-rs-domain` passes locally on `HEAD`.
- [ ] CI run on this PR exercises the new `docs` job end-to-end.