### PR TITLE
refactor(websocket)!: rename StreamSession to WebSocketStreamSession (closes #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING** `pjson_rs::infrastructure::websocket::StreamSession` renamed to `WebSocketStreamSession` to remove the name collision with the domain-layer `crate::domain::aggregates::StreamSession`. The two types remain deliberately disjoint — the WebSocket controller maintains an ephemeral, transport-local session model that does not share state with `POST /pjs/sessions`. The new name and the type's doc comment make this explicit at the call site (closes #239).
 - **BREAKING** `AdaptiveFrameStream::into_stream`, `BatchFrameStream::into_stream`, `PriorityFrameStream::into_stream`, `create_streaming_response`, and `create_streaming_response_with_content_type` now operate on `Vec<u8>` instead of `String`. Threading bytes end-to-end is what makes `AdaptiveFrameStream::with_compression(true)` actually usable — the previous `String` pipeline rejected gzip output (which is binary, not UTF-8) with `StreamError::Io("compressed output is not valid UTF-8")` for every chunk. Callers that need a textual view of an uncompressed frame can decode each payload with `std::str::from_utf8`. Pre-1.0 breaking change; no deprecation cycle (closes #226).
 
 ### Fixed

--- a/crates/pjs-core/src/infrastructure/websocket/client.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/client.rs
@@ -18,14 +18,14 @@ use url::Url;
 /// WebSocket client for receiving PJS streams
 pub struct PjsWebSocketClient {
     url: Url,
-    sessions: Arc<RwLock<HashMap<String, StreamSession>>>,
+    sessions: Arc<RwLock<HashMap<String, ClientStreamSession>>>,
     message_tx: mpsc::UnboundedSender<WsMessage>,
     message_rx: Arc<RwLock<Option<mpsc::UnboundedReceiver<WsMessage>>>>,
 }
 
 /// Client-side stream session
 #[derive(Debug)]
-struct StreamSession {
+struct ClientStreamSession {
     id: String,
     created_at: Instant,
     received_frames: HashMap<u32, ReceivedFrame>,
@@ -174,7 +174,7 @@ impl PjsWebSocketClient {
             .map_err(|e| PjsError::ClientError(format!("Failed to send stream request: {e}")))?;
 
         // Initialize session tracking
-        let session = StreamSession {
+        let session = ClientStreamSession {
             id: session_id.clone(),
             created_at: Instant::now(),
             received_frames: HashMap::new(),
@@ -246,7 +246,7 @@ impl PjsWebSocketClient {
     }
 
     async fn handle_incoming_message(
-        sessions: Arc<RwLock<HashMap<String, StreamSession>>>,
+        sessions: Arc<RwLock<HashMap<String, ClientStreamSession>>>,
         message_tx: mpsc::UnboundedSender<WsMessage>,
         message: WsMessage,
     ) -> PjsResult<()> {

--- a/crates/pjs-core/src/infrastructure/websocket/mod.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/mod.rs
@@ -96,9 +96,22 @@ impl Default for StreamOptions {
     }
 }
 
-/// WebSocket streaming session state
+/// WebSocket streaming session state.
+///
+/// This type is intentionally distinct from the domain-layer
+/// [`crate::domain::aggregates::StreamSession`] aggregate. The WebSocket
+/// transport maintains an ephemeral, transport-local session model with raw
+/// `String` identifiers and an in-memory `HashMap` keyed off
+/// [`AdaptiveStreamController`]; it does **not** share state with the
+/// `StreamRepositoryGat`-backed domain session created by
+/// `POST /pjs/sessions`. Sessions created over WebSocket cannot be addressed
+/// over HTTP and vice versa, and dictionary training, auth, and rate-limit
+/// middleware applied to the HTTP router do not apply to this controller.
+///
+/// See issue #239 for the full rationale and the deliberate split between
+/// the two session models.
 #[derive(Debug)]
-pub struct StreamSession {
+pub struct WebSocketStreamSession {
     pub id: String,
     pub created_at: Instant,
     pub options: StreamOptions,
@@ -199,7 +212,7 @@ pub trait WebSocketTransport: Send + Sync {
 
 /// Adaptive streaming controller
 pub struct AdaptiveStreamController {
-    sessions: Arc<RwLock<HashMap<String, StreamSession>>>,
+    sessions: Arc<RwLock<HashMap<String, WebSocketStreamSession>>>,
     frame_tx: broadcast::Sender<(String, WsMessage)>,
 }
 
@@ -222,7 +235,7 @@ impl AdaptiveStreamController {
             metadata: std::collections::HashMap::new(),
         }]; // Simplified for now
 
-        let session = StreamSession {
+        let session = WebSocketStreamSession {
             id: session_id.clone(),
             created_at: Instant::now(),
             options,


### PR DESCRIPTION
## Summary

- Renames the public `pjson_rs::infrastructure::websocket::StreamSession` to `WebSocketStreamSession` to remove the name collision with the domain aggregate `crate::domain::aggregates::StreamSession`.
- Renames the private client-side `StreamSession` in `websocket::client` to `ClientStreamSession` for the same reason.
- Adds a doc comment on `WebSocketStreamSession` explicitly stating that the WebSocket session model is ephemeral, transport-local, and deliberately disjoint from the `StreamRepositoryGat`-backed domain session created by `POST /pjs/sessions`, with a pointer to #239 for rationale.

This implements suggested resolution **#2** from #239 (document the split, rename to remove the collision). Resolutions #1 (unify) and #3 (bridge dictionary store) are larger design exercises and remain out of scope for this P3 fix.

## Breaking Change

`pjson_rs::infrastructure::websocket::StreamSession` no longer exists. Callers must import `WebSocketStreamSession` instead. No external code in the workspace referenced the old name (only the module itself and the closed `pub use websocket::*` re-export chain), so the blast radius outside this PR is limited to downstream consumers that imported the type directly.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1034/1034 pass)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTDOCFLAGS=\"--deny rustdoc::broken_intra_doc_links\" cargo doc --no-deps -p pjson-rs -p pjson-rs-domain --all-features`

Closes #239