### PR TITLE
refactor(domain)!: route child-stream mutations through StreamSession aggregate root (closes #259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** `StreamSession::get_stream_mut` removed. Child-stream mutation now flows through two new aggregate-root methods: `update_stream_config(stream_id, config)` and `create_stream_patch_frames(stream_id, priority_threshold, max_frames)`. Both bump the session-level `updated_at` timestamp and raise the appropriate domain events (`StreamConfigUpdated`, `FramesBatched`); `create_stream_patch_frames` additionally maintains `stats.total_frames` so session-level metrics stay consistent with the per-stream mutation. Previously `command_handlers.rs` reached inside the aggregate via `get_stream_mut` to call `Stream::update_config` (silent: no event, no timestamp bump) and `Stream::create_patch_frames` (silent: stale `stats.total_frames`, no `FramesBatched` event). The removal closes the longest-standing entry (D2) in the architectural-baseline drift register. Pre-1.0 breaking change; no deprecation cycle (closes #259).
+
 ### Added
 
 - `pjson_rs_domain::services::compute_priority` and `PriorityHeuristicConfig` — single source of truth for the priority heuristic shared by every transport. `Stream::compute_priority` (HTTP path) and `pjs_wasm::priority_assignment::PriorityAssigner` (WebAssembly path) now both delegate here, so the same `(path, value)` input yields the same `Priority` regardless of how it reaches the client (closes #242).

--- a/crates/pjs-core/src/application/handlers/command_handlers.rs
+++ b/crates/pjs-core/src/application/handlers/command_handlers.rs
@@ -167,11 +167,9 @@ where
                 .map_err(ApplicationError::Domain)?;
 
             // Update stream configuration if provided
-            if let Some(config) = command.config
-                && let Some(stream) = session.get_stream_mut(stream_id)
-            {
-                stream
-                    .update_config(config)
+            if let Some(config) = command.config {
+                session
+                    .update_stream_config(stream_id, config)
                     .map_err(ApplicationError::Domain)?;
             }
 
@@ -311,21 +309,20 @@ where
                     ApplicationError::NotFound(format!("Session {} not found", command.session_id))
                 })?;
 
-            // Get stream
-            let stream = session
-                .get_stream_mut(command.stream_id.into())
-                .ok_or_else(|| {
-                    ApplicationError::NotFound(format!("Stream {} not found", command.stream_id))
-                })?;
-
-            // Generate frames
+            // Generate frames through the aggregate root so session-level
+            // stats and events stay consistent with the child stream mutation.
             let priority = command
                 .priority_threshold
                 .try_into()
                 .map_err(ApplicationError::Domain)?;
-            let frames = stream
-                .create_patch_frames(priority, command.max_frames)
-                .map_err(ApplicationError::Domain)?;
+            let frames = session
+                .create_stream_patch_frames(command.stream_id.into(), priority, command.max_frames)
+                .map_err(|e| match e {
+                    crate::domain::DomainError::StreamNotFound(_) => ApplicationError::NotFound(
+                        format!("Stream {} not found", command.stream_id),
+                    ),
+                    other => ApplicationError::Domain(other),
+                })?;
 
             // WebSocket frame production runs through a disjoint session model
             // (`infrastructure/websocket`) and does not increment this counter, so

--- a/crates/pjs-core/src/domain/aggregates/stream_session.rs
+++ b/crates/pjs-core/src/domain/aggregates/stream_session.rs
@@ -220,9 +220,66 @@ impl StreamSession {
         self.streams.get(&stream_id)
     }
 
-    /// Get mutable stream by ID
-    pub fn get_stream_mut(&mut self, stream_id: StreamId) -> Option<&mut Stream> {
-        self.streams.get_mut(&stream_id)
+    /// Update configuration of a child stream through the aggregate root.
+    ///
+    /// Child mutations must flow through the aggregate so the session-level
+    /// timestamp is bumped and a [`DomainEvent::StreamConfigUpdated`] event is
+    /// raised. Application code MUST NOT reach into `Stream` directly to
+    /// mutate config — the previous `get_stream_mut` accessor that allowed
+    /// this was a DDD violation (see issue #259).
+    pub fn update_stream_config(
+        &mut self,
+        stream_id: StreamId,
+        config: StreamConfig,
+    ) -> DomainResult<()> {
+        let stream = self
+            .streams
+            .get_mut(&stream_id)
+            .ok_or_else(|| DomainError::StreamNotFound(stream_id.to_string()))?;
+
+        stream.update_config(config)?;
+        self.update_timestamp();
+
+        self.add_event(DomainEvent::StreamConfigUpdated {
+            session_id: self.id,
+            stream_id,
+            timestamp: Utc::now(),
+        });
+
+        Ok(())
+    }
+
+    /// Generate patch frames for a child stream through the aggregate root.
+    ///
+    /// Wraps [`Stream::create_patch_frames`] so that session-level statistics
+    /// (`stats.total_frames`) and the `updated_at` timestamp stay consistent
+    /// with the child mutation, and a [`DomainEvent::FramesBatched`] event is
+    /// raised when frames are produced.
+    pub fn create_stream_patch_frames(
+        &mut self,
+        stream_id: StreamId,
+        priority_threshold: Priority,
+        max_frames: usize,
+    ) -> DomainResult<Vec<Frame>> {
+        let stream = self
+            .streams
+            .get_mut(&stream_id)
+            .ok_or_else(|| DomainError::StreamNotFound(stream_id.to_string()))?;
+
+        let frames = stream.create_patch_frames(priority_threshold, max_frames)?;
+
+        self.stats.total_frames += frames.len() as u64;
+        self.update_timestamp();
+
+        if !frames.is_empty() {
+            self.add_event(DomainEvent::FramesBatched {
+                session_id: self.id,
+                frame_count: frames.len(),
+                timestamp: Utc::now(),
+            });
+        }
+
+        Ok(frames)
     }
 
     /// Activate session

--- a/crates/pjs-core/tests/stream_session_comprehensive.rs
+++ b/crates/pjs-core/tests/stream_session_comprehensive.rs
@@ -764,16 +764,6 @@ fn test_get_stream_nonexistent() {
     assert!(session.get_stream(fake_id).is_none());
 }
 
-#[test]
-fn test_get_stream_mut_nonexistent() {
-    let mut session = StreamSession::new(default_config());
-    session.activate().unwrap();
-
-    let fake_id = StreamId::new();
-
-    assert!(session.get_stream_mut(fake_id).is_none());
-}
-
 // ============================================================================
 // Priority Frame Creation (Complex Scenario)
 // ============================================================================


### PR DESCRIPTION
## Summary

- Remove `StreamSession::get_stream_mut` and add two aggregate-root methods so child-stream mutations stay consistent with session-level state and events.
- `update_stream_config(stream_id, config)` — bumps `updated_at`, raises `DomainEvent::StreamConfigUpdated`.
- `create_stream_patch_frames(stream_id, priority, max_frames)` — bumps `updated_at`, increments `stats.total_frames`, raises `DomainEvent::FramesBatched` when frames are produced.
- `CreateStreamCommand` and `GenerateFramesCommand` updated to use the new methods; `GenerateFramesCommand` maps `DomainError::StreamNotFound` to `ApplicationError::NotFound` so the pre-existing 404 contract is preserved.
- Closes the longest-standing entry (D2) in the architectural-baseline drift register.

## Breaking change

`StreamSession::get_stream_mut` is removed. Pre-1.0 breaking change; no deprecation cycle. Documented in `CHANGELOG.md` under `[Unreleased] / Changed`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features` (2664 passed, 3 skipped)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjson-rs -p pjson-rs-domain`

Closes #259