### PR TITLE
fix(js-client): patch high-severity npm audit vulnerabilities

### DIFF
--- a/crates/pjs-js-client/package-lock.json
+++ b/crates/pjs-js-client/package-lock.json
@@ -3050,9 +3050,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5045,9 +5045,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/crates/pjs-js-client/package.json
+++ b/crates/pjs-js-client/package.json
@@ -82,6 +82,6 @@
   "overrides": {
     "minimatch": "^10.2.1",
     "shell-quote": "^1.8.4",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `brace-expansion` to 5.0.9, fixing GHSA-rgw5-rvv9-x895 (high, DoS via unbounded intermediate arrays)
- Bump `js-yaml` to 4.3.1, fixing GHSA-5p4m-2wfm-xmqj (high, quadratic CPU consumption in `!!omap` resolution)
- Both are transitive dev dependencies in `crates/pjs-js-client`; `npm audit` now reports 0 vulnerabilities

This unblocks the OSV Security Scan CI check, which currently fails on `main` and on open PRs (including #340) due to these pre-existing advisories, unrelated to any specific PR's own changes.

## Test plan
- [x] `npm audit` reports 0 vulnerabilities in `crates/pjs-js-client`
- [x] Lockfile diff confined to the two flagged packages