### PR TITLE
ci: exclude pjs-wasm from windows build/doctest to fix check-cfg crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,12 @@ jobs:
       # Compile tests and produce a self-contained archive.  The archive
       # bundles test binaries + metadata so the test job can run without
       # recompiling.
+      # pjs-wasm is excluded: every one of its tests is gated to the wasm32
+      # target and its rustdoc examples are JS/ignored, so compiling it here
+      # adds no coverage. Worse, its transitive web-sys dependency declares
+      # ~1800 features, and Cargo's auto-generated --check-cfg argument for
+      # it (~40k chars) exceeds Windows' CreateProcess command-line limit,
+      # crashing sccache with os error 206. See #344.
       - name: Build test archive
         env:
           RUSTC_WRAPPER: sccache
@@ -168,6 +174,7 @@ jobs:
         run: >-
           cargo nextest archive
           --workspace
+          --exclude pjs-wasm
           --features "default${{ matrix.extra_features }}"
           --lib --bins
           --archive-file nextest-archive.tar.zst
@@ -255,6 +262,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
 
+      # pjs-wasm excluded for the same reason as the build job above: no
+      # runnable doctests (all examples are JS/ignored) and its web-sys
+      # dependency crashes sccache on Windows. See #344.
       - name: Run doctests
         env:
           RUSTC_WRAPPER: sccache
@@ -262,6 +272,7 @@ jobs:
         run: >-
           cargo test
           --workspace
+          --exclude pjs-wasm
           --doc
 
       - name: Print sccache stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI
+
+- Exclude `pjs-wasm` from the `--workspace` build/doctest steps on `build` and `doctest` jobs. Its transitive `web-sys` dependency declares ~1800 features; Cargo's auto-generated `--check-cfg` argument for it exceeds Windows' command-line length limit and crashed `sccache` on `windows-latest` (`os error 206`), intermittently blocking merges. `pjs-wasm`'s tests are all gated to `target_arch = "wasm32"` and its rustdoc examples are JS-only, so nothing was actually being exercised natively (#344)
+
 ## [0.6.2] - 2026-07-27
 
 ### Security


### PR DESCRIPTION
## Summary

- `Build (windows-latest, system)` and `Doctests (windows-latest)` — both required for the `ci-success` gate — have been failing intermittently for weeks whenever `web-sys` needs a cold-cache rebuild, blocking merges (most recently PR #340, an unrelated `clap` bump).
- Root cause: `web-sys` (pulled in transitively via `pjs-wasm` -> `tsify` -> `gloo-utils`) declares ~1800 features. Cargo's auto-generated `--check-cfg` argument for it produces a ~40k character `rustc` invocation, which exceeds Windows' `CreateProcess` command-line limit (~32767 chars). `sccache` then fails to spawn `rustc.exe` with `os error 206`.
- `pjs-wasm` gains no coverage from being compiled for the native host in these two jobs: every test is gated `#[cfg(all(test, target_arch = "wasm32"))]` and every rustdoc example is `javascript` or `rust,ignore`. Excluding it from the `--workspace` build/doctest steps removes zero test coverage while permanently fixing the Windows crash.

Fixes #344

## Test plan

- [x] `cargo check --workspace --exclude pjs-wasm --lib --bins --features default` locally — confirms `web-sys`/`wasm-bindgen`/`pjs-wasm` are no longer compiled
- [x] `actionlint .github/workflows/ci.yml` — no new issues introduced
- [ ] CI on this PR (`Build (windows-latest, *)`, `Doctests (windows-latest)`) turns green