### PR TITLE
fix(security): HTTP rate limiter trusts unauthenticated X-Forwarded-For/X-Real-IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- HTTP rate limiter (`RateLimitMiddleware`) no longer trusts `X-Forwarded-For`/`X-Real-IP` from arbitrary clients — it keys on the real TCP peer address via axum's `ConnectInfo<SocketAddr>` by default, closing a bypass where a client could send a fresh spoofed header on every request to obtain a fresh rate-limit bucket. Proxy-header support is now opt-in via `RateLimitConfig::with_trusted_proxies`, which only honors the forwarded headers when the real peer address is in an explicit allowlist. `X-Forwarded-For` is read across all header lines with that name and parsed right-to-left, skipping entries that are themselves trusted proxies, so a client sitting behind a trusted proxy cannot forge a fresh bucket by varying the client-supplied (leftmost) entry or by adding its own header line; the walk fails closed (falls back to `X-Real-IP`, then the peer address) on the first unparseable entry rather than skipping past it. Allowlist and peer comparisons canonicalize IPv4-mapped IPv6 addresses so a dual-stack listener still matches a plain-IPv4 allowlist entry. A one-time warning is logged if a request has no `ConnectInfo` extension, since that otherwise silently collapses every client onto a single shared bucket (#336)
+
+### Fixed
+
+- Removed stale TODO comments in `axum_adapter.rs` describing authentication and HTTP rate limiting as unimplemented; both already exist (`ApiKeyAuthLayer`/`JwtAuthLayer` in `infrastructure::http::auth`, `RateLimitMiddleware` in `infrastructure::http::middleware`) and are now documented and cross-referenced in place (#319)
+
 ### CI
 
 - Exclude `pjs-wasm` from the `--workspace` build/doctest steps on `build` and `doctest` jobs. Its transitive `web-sys` dependency declares ~1800 features; Cargo's auto-generated `--check-cfg` argument for it exceeds Windows' command-line length limit and crashed `sccache` on `windows-latest` (`os error 206`), intermittently blocking merges. `pjs-wasm`'s tests are all gated to `target_arch = "wasm32"` and its rustdoc examples are JS-only, so nothing was actually being exercised natively (#344)

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -384,10 +384,11 @@ impl From<SessionHealth> for SessionHealthResponse {
 /// # Security Note
 ///
 /// This is suitable for local development only. For production, use
-/// [`create_pjs_router_with_config`] with an explicit [`HttpServerConfig`].
-///
-/// TODO: Implement authentication strategy before production deployment.
-/// Options: API keys, JWT tokens, OAuth2/OIDC
+/// [`create_pjs_router_with_config`] with an explicit [`HttpServerConfig`], and
+/// apply authentication via [`create_pjs_router_with_auth`] or
+/// [`create_pjs_router_with_rate_limit_and_auth`] — API key and JWT layers are
+/// available in [`crate::infrastructure::http::auth`]
+/// (`ApiKeyAuthLayer`, `JwtAuthLayer`).
 pub fn create_pjs_router<R, P, S>() -> Router<PjsAppState<R, P, S>>
 where
     R: StreamRepositoryGat + Send + Sync + 'static,
@@ -436,7 +437,13 @@ where
 ///
 /// # Security Note
 ///
-/// Rate limiting is applied globally to all endpoints.
+/// Rate limiting is applied globally to all endpoints, keyed on the real TCP
+/// peer address by default — the router must be served with
+/// `into_make_service_with_connect_info::<std::net::SocketAddr>()` (as done for
+/// the WebSocket upgrade handler) so that peer address is populated; otherwise
+/// every request falls back to the same key (`127.0.0.1`). To trust
+/// `X-Forwarded-For`/`X-Real-IP` behind a reverse proxy, opt in via
+/// [`RateLimitConfig::with_trusted_proxies`](crate::infrastructure::http::middleware::RateLimitConfig::with_trusted_proxies).
 /// Returns 429 Too Many Requests with Retry-After header when limit exceeded.
 /// Adds X-RateLimit-* headers per RFC 6585.
 pub fn create_pjs_router_with_rate_limit<R, P, S>(
@@ -1098,27 +1105,14 @@ where
     Ok(Json(response))
 }
 
-// TODO(CQ-004): Implement HTTP rate limiting middleware
-//
-// Recommended implementation:
-// - Add Arc<WebSocketRateLimiter> to PjsAppState
-// - Use 100 requests/minute per IP with burst allowance
-// - Extract IP from ConnectInfo<SocketAddr>
-// - Return 429 Too Many Requests on limit exceeded
-//
-// Example:
-// ```ignore
-// async fn rate_limit_middleware(
-//     State(limiter): State<Arc<WebSocketRateLimiter>>,
-//     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-//     req: Request,
-//     next: Next,
-// ) -> Result<Response, StatusCode> {
-//     limiter.check_request(addr.ip())
-//         .map_err(|_| StatusCode::TOO_MANY_REQUESTS)?;
-//     Ok(next.run(req).await)
-// }
-// ```
+// HTTP rate limiting is implemented by `RateLimitMiddleware`
+// (crate::infrastructure::http::middleware), wired in via
+// `create_pjs_router_with_rate_limit[_and_config]` and
+// `create_pjs_router_with_rate_limit_and_auth` above. It keys on the real
+// ConnectInfo<SocketAddr> peer address by default; see
+// `RateLimitConfig::with_trusted_proxies` to opt in to trusting
+// X-Forwarded-For/X-Real-IP behind a known reverse proxy.
+
 /// PJS-specific errors for HTTP endpoints
 #[derive(Debug, thiserror::Error)]
 pub enum PjsError {

--- a/crates/pjs-core/src/infrastructure/http/middleware.rs
+++ b/crates/pjs-core/src/infrastructure/http/middleware.rs
@@ -1,11 +1,12 @@
 //! HTTP middleware for PJS optimization and monitoring
 
 use axum::{
-    extract::Request,
+    extract::{ConnectInfo, Request},
     http::{HeaderMap, HeaderValue, StatusCode, header},
     middleware::Next,
     response::Response,
 };
+use std::net::SocketAddr;
 use std::time::Instant;
 use std::{
     future::Future,
@@ -139,6 +140,51 @@ where
     }
 }
 
+/// Opt-in trusted-proxy allowlist for the HTTP rate limiter.
+///
+/// By default, [`RateLimitMiddleware`] keys rate limiting on the real TCP peer
+/// address and never trusts `X-Forwarded-For`/`X-Real-IP` — an unauthenticated
+/// client could otherwise send a fresh spoofed value on every request to get a
+/// fresh rate-limit bucket, fully bypassing the limiter. Set this only for
+/// deployments that sit behind a known reverse proxy or load balancer whose
+/// peer address(es) are listed here; requests from any other peer always use
+/// the real peer address regardless of these headers.
+///
+/// # Proxy contract
+///
+/// `X-Forwarded-For` is read right-to-left and takes precedence over
+/// `X-Real-IP` when both are present. The trusted proxy must *append* the
+/// address it saw the connection from to `X-Forwarded-For` rather than
+/// overwrite it (e.g. nginx's `$proxy_add_x_forwarded_for`, or any proxy that
+/// merges into a single header line rather than emitting a new one). Proxies
+/// that instead emit `<ip>:<port>` or bracketed IPv6 entries are not
+/// supported by this simple allowlist — the walk fails closed on the first
+/// unparseable entry (falls back to `X-Real-IP`, then the peer address)
+/// rather than skipping it and guessing from what remains. Repeated
+/// `X-Forwarded-For` header lines are read and treated as one comma-joined
+/// list in line order, per RFC 9110.
+#[derive(Debug, Clone, Default)]
+pub struct TrustedProxyConfig {
+    /// Peer addresses (the proxy's own TCP source address) allowed to supply
+    /// `X-Forwarded-For`/`X-Real-IP`.
+    pub trusted_proxies: Vec<std::net::IpAddr>,
+}
+
+impl TrustedProxyConfig {
+    /// Build a trusted-proxy config from an explicit allowlist of proxy addresses.
+    pub fn new(trusted_proxies: Vec<std::net::IpAddr>) -> Self {
+        Self { trusted_proxies }
+    }
+
+    /// Whether `ip` (already canonicalized via [`IpAddr::to_canonical`]) is in
+    /// the allowlist. Allowlist entries are canonicalized before comparison so
+    /// an IPv4 proxy configured as `10.0.0.1` still matches when it arrives as
+    /// the IPv4-mapped IPv6 address `::ffff:10.0.0.1` on a dual-stack listener.
+    fn contains(&self, ip: std::net::IpAddr) -> bool {
+        self.trusted_proxies.iter().any(|p| p.to_canonical() == ip)
+    }
+}
+
 /// Rate limiting configuration for HTTP endpoints
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
@@ -146,6 +192,9 @@ pub struct RateLimitConfig {
     pub max_requests_per_window: u32,
     /// Time window duration (default: 60 seconds)
     pub window_duration: std::time::Duration,
+    /// Opt-in trusted-proxy allowlist. `None` (the default) always keys the
+    /// rate limiter on the real TCP peer address. See [`TrustedProxyConfig`].
+    pub trusted_proxies: Option<TrustedProxyConfig>,
 }
 
 impl Default for RateLimitConfig {
@@ -153,6 +202,7 @@ impl Default for RateLimitConfig {
         Self {
             max_requests_per_window: 100,
             window_duration: std::time::Duration::from_secs(60),
+            trusted_proxies: None,
         }
     }
 }
@@ -163,12 +213,19 @@ impl RateLimitConfig {
         Self {
             max_requests_per_window: requests_per_minute,
             window_duration: std::time::Duration::from_secs(60),
+            trusted_proxies: None,
         }
     }
 
     /// Override the window duration that `max_requests_per_window` applies to.
     pub fn with_window(mut self, duration: std::time::Duration) -> Self {
         self.window_duration = duration;
+        self
+    }
+
+    /// Opt in to trusting `X-Forwarded-For`/`X-Real-IP` from the given proxy allowlist.
+    pub fn with_trusted_proxies(mut self, config: TrustedProxyConfig) -> Self {
+        self.trusted_proxies = Some(config);
         self
     }
 }
@@ -181,11 +238,13 @@ impl RateLimitConfig {
 #[derive(Clone)]
 pub struct RateLimitMiddleware {
     limiter: std::sync::Arc<crate::security::rate_limit::WebSocketRateLimiter>,
+    trusted_proxies: Option<TrustedProxyConfig>,
 }
 
 impl RateLimitMiddleware {
     /// Build a fresh middleware with its own internal `WebSocketRateLimiter`.
     pub fn new(config: RateLimitConfig) -> Self {
+        let trusted_proxies = config.trusted_proxies.clone();
         let rate_limit_config = crate::security::rate_limit::RateLimitConfig {
             max_requests_per_window: config.max_requests_per_window,
             window_duration: config.window_duration,
@@ -196,6 +255,7 @@ impl RateLimitMiddleware {
             limiter: std::sync::Arc::new(crate::security::rate_limit::WebSocketRateLimiter::new(
                 rate_limit_config,
             )),
+            trusted_proxies,
         }
     }
 
@@ -203,7 +263,16 @@ impl RateLimitMiddleware {
     pub fn from_limiter(
         limiter: std::sync::Arc<crate::security::rate_limit::WebSocketRateLimiter>,
     ) -> Self {
-        Self { limiter }
+        Self {
+            limiter,
+            trusted_proxies: None,
+        }
+    }
+
+    /// Opt in to trusting `X-Forwarded-For`/`X-Real-IP` from the given proxy allowlist.
+    pub fn with_trusted_proxies(mut self, config: TrustedProxyConfig) -> Self {
+        self.trusted_proxies = Some(config);
+        self
     }
 }
 
@@ -214,6 +283,7 @@ impl<S> Layer<S> for RateLimitMiddleware {
         RateLimitService {
             inner,
             limiter: self.limiter.clone(),
+            trusted_proxies: self.trusted_proxies.clone(),
         }
     }
 }
@@ -223,6 +293,7 @@ impl<S> Layer<S> for RateLimitMiddleware {
 pub struct RateLimitService<S> {
     inner: S,
     limiter: std::sync::Arc<crate::security::rate_limit::WebSocketRateLimiter>,
+    trusted_proxies: Option<TrustedProxyConfig>,
 }
 
 impl<S> Service<Request> for RateLimitService<S>
@@ -240,11 +311,11 @@ where
 
     fn call(&mut self, request: Request) -> Self::Future {
         let limiter = self.limiter.clone();
+        let trusted_proxies = self.trusted_proxies.clone();
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            // Extract client IP from connection info or X-Forwarded-For header
-            let client_ip = extract_client_ip(&request);
+            let client_ip = extract_client_ip(&request, trusted_proxies.as_ref());
 
             // Check rate limit
             match limiter.check_request(client_ip) {
@@ -283,38 +354,108 @@ where
     }
 }
 
-/// Extract client IP address from request
+/// Extract the client IP address used as the rate-limit key.
 ///
-/// Priority:
-/// 1. X-Forwarded-For header (behind proxy)
-/// 2. X-Real-IP header
-/// 3. Default to localhost (fallback)
-fn extract_client_ip(request: &Request) -> std::net::IpAddr {
+/// Always trusts the real TCP peer address first, populated via axum's
+/// [`ConnectInfo`] extension — the router must be served with
+/// `into_make_service_with_connect_info::<SocketAddr>()`, otherwise no
+/// `ConnectInfo` extension is present, every client collapses onto a single
+/// shared bucket keyed on `127.0.0.1`, and a one-time warning is logged (see
+/// [`warn_missing_connect_info`]).
+///
+/// `X-Forwarded-For`/`X-Real-IP` are only consulted when `trusted_proxies` is
+/// set and the real peer address is in its allowlist. Trusting these headers
+/// unconditionally would let any client forge a fresh rate-limit bucket on
+/// every request, fully bypassing the limiter. Both the peer address and
+/// allowlist entries are compared via [`IpAddr::to_canonical`] so an IPv4
+/// proxy is still recognized when it arrives IPv4-mapped on a dual-stack
+/// listener.
+fn extract_client_ip(
+    request: &Request,
+    trusted_proxies: Option<&TrustedProxyConfig>,
+) -> std::net::IpAddr {
     use std::net::{IpAddr, Ipv4Addr};
 
-    // Try X-Forwarded-For header
-    if let Some(ip) = request
-        .headers()
-        .get("x-forwarded-for")
-        .and_then(|h| h.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .and_then(|first| first.trim().parse::<IpAddr>().ok())
+    let Some(peer) = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip().to_canonical())
+    else {
+        warn_missing_connect_info();
+        return IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+    };
+
+    if let Some(proxies) = trusted_proxies
+        && proxies.contains(peer)
+        && let Some(forwarded_ip) = extract_forwarded_ip(request.headers(), proxies)
     {
-        return ip;
+        return forwarded_ip;
     }
 
-    // Try X-Real-IP header
-    if let Some(ip) = request
-        .headers()
+    peer
+}
+
+/// Log once (per process) that a request arrived with no `ConnectInfo`
+/// extension, so misconfiguration is loud rather than silently collapsing
+/// every client onto one rate-limit bucket.
+fn warn_missing_connect_info() {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        tracing::warn!(
+            "RateLimitMiddleware: request has no ConnectInfo<SocketAddr> extension; \
+             serve the router with `.into_make_service_with_connect_info::<SocketAddr>()` \
+             or every client will share a single rate-limit bucket keyed on 127.0.0.1 \
+             (logged once)"
+        );
+    });
+}
+
+/// Parse the client IP from `X-Forwarded-For` or `X-Real-IP`.
+///
+/// Only called for peers already verified against [`TrustedProxyConfig`] —
+/// these headers must never be trusted from an unverified peer.
+///
+/// `X-Forwarded-For` is walked right-to-left — across all header lines with
+/// that name, since `HeaderMap` allows repeats and they are semantically one
+/// comma-joined list in line order — skipping any entry that is itself a
+/// trusted proxy, and returns the first entry that is not. A well-behaved
+/// proxy *appends* the address it saw the connection from, so the rightmost
+/// non-trusted entry is the one appended by the closest trusted hop and
+/// cannot be forged by the client — taking the leftmost (client-supplied)
+/// entry instead would let a client behind a trusted proxy forge a fresh
+/// value on every request and reopen the exact bypass this module exists to
+/// close.
+///
+/// The walk **fails closed** on the first unparseable entry: it stops and
+/// falls through to `X-Real-IP` rather than skipping past the malformed
+/// entry into entries further left, which are progressively more
+/// attacker-controlled the further left they sit in the chain.
+fn extract_forwarded_ip(
+    headers: &HeaderMap,
+    trusted_proxies: &TrustedProxyConfig,
+) -> Option<std::net::IpAddr> {
+    let entries: Vec<&str> = headers
+        .get_all("x-forwarded-for")
+        .iter()
+        .filter_map(|h| h.to_str().ok())
+        .flat_map(|s| s.split(','))
+        .collect();
+
+    for entry in entries.into_iter().rev() {
+        let Ok(ip) = entry.trim().parse::<std::net::IpAddr>() else {
+            break;
+        };
+        let canonical = ip.to_canonical();
+        if !trusted_proxies.contains(canonical) {
+            return Some(canonical);
+        }
+    }
+
+    headers
         .get("x-real-ip")
         .and_then(|h| h.to_str().ok())
-        .and_then(|s| s.parse::<IpAddr>().ok())
-    {
-        return ip;
-    }
-
-    // Fallback to localhost
-    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+        .and_then(|s| s.trim().parse::<std::net::IpAddr>().ok())
+        .map(|ip| ip.to_canonical())
 }
 
 /// Add X-RateLimit-* headers to response per RFC 6585

--- a/crates/pjs-core/src/infrastructure/http/mod.rs
+++ b/crates/pjs-core/src/infrastructure/http/mod.rs
@@ -23,7 +23,7 @@ pub use axum_adapter::{
 #[cfg(feature = "http-server")]
 pub use axum_adapter::{create_pjs_router_with_auth, create_pjs_router_with_rate_limit_and_auth};
 pub use axum_extension::{HttpExtensionConfig, PjsExtension};
-pub use middleware::{RateLimitConfig, RateLimitMiddleware};
+pub use middleware::{RateLimitConfig, RateLimitMiddleware, TrustedProxyConfig};
 pub use streaming::{
     AdaptiveFrameStream, BatchFrameStream, PriorityFrameStream, StreamError, StreamFormat,
     create_streaming_response, create_streaming_response_with_content_type,

--- a/crates/pjs-core/tests/http_middleware_tests.rs
+++ b/crates/pjs-core/tests/http_middleware_tests.rs
@@ -17,16 +17,18 @@ mod common;
 use axum::{
     Router,
     body::Body,
+    extract::ConnectInfo,
     http::{Method, Request, StatusCode},
     response::IntoResponse,
     routing::get,
 };
 use pjson_rs::infrastructure::http::{
-    HttpServerConfig, RateLimitConfig, RateLimitMiddleware,
+    HttpServerConfig, RateLimitConfig, RateLimitMiddleware, TrustedProxyConfig,
     auth::{ApiKeyAuthLayer, ApiKeyConfig, AuthConfigError},
     axum_adapter::{PjsAppState, create_pjs_router, create_pjs_router_with_auth},
     create_pjs_router_with_rate_limit_and_auth,
 };
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tower::ServiceExt;
 
@@ -335,6 +337,287 @@ async fn test_rate_limit_429_includes_retry_after() {
     assert!(
         resp.headers().contains_key("Retry-After"),
         "429 response must include Retry-After header"
+    );
+}
+
+// ============================================================================
+// RateLimitMiddleware — spoofed proxy headers must not bypass the limiter
+// ============================================================================
+
+fn peer(addr: [u8; 4], port: u16) -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::from((IpAddr::V4(Ipv4Addr::from(addr)), port)))
+}
+
+fn request_from_peer(peer_addr: ConnectInfo<SocketAddr>, forwarded_for: &str) -> Request<Body> {
+    let mut req = Request::builder()
+        .uri("/test")
+        .header("X-Forwarded-For", forwarded_for)
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut().insert(peer_addr);
+    req
+}
+
+/// Two requests from the same real TCP peer but with different spoofed
+/// `X-Forwarded-For` values must share the same rate-limit bucket — proving
+/// the header is ignored by default and cannot be used to dodge the limiter.
+#[tokio::test]
+async fn test_rate_limit_ignores_spoofed_forwarded_for_by_default() {
+    let config = RateLimitConfig::new(1).with_window(Duration::from_secs(60));
+    let app = make_rate_limit_router(config);
+
+    let same_peer = peer([203, 0, 113, 9], 51000);
+
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(same_peer, "1.1.1.1"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK, "first request must pass");
+
+    // Different spoofed X-Forwarded-For, same real peer — must still be throttled.
+    let resp2 = app
+        .oneshot(request_from_peer(same_peer, "2.2.2.2"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "spoofed X-Forwarded-For must not grant a fresh rate-limit bucket"
+    );
+}
+
+/// Requests from two distinct real peers must get independent buckets, even
+/// when they send the same `X-Forwarded-For` value.
+#[tokio::test]
+async fn test_rate_limit_keys_on_real_peer_not_header() {
+    let config = RateLimitConfig::new(1).with_window(Duration::from_secs(60));
+    let app = make_rate_limit_router(config);
+
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(peer([198, 51, 100, 1], 40000), "9.9.9.9"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(peer([198, 51, 100, 2], 40001), "9.9.9.9"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::OK,
+        "a different real peer must not be throttled by another peer's budget"
+    );
+}
+
+/// With trusted-proxy support explicitly enabled and the peer address in the
+/// allowlist, `X-Forwarded-For` is honored: two requests through the same
+/// trusted proxy but carrying different forwarded client IPs get independent
+/// buckets.
+#[tokio::test]
+async fn test_rate_limit_trusted_proxy_honors_forwarded_for() {
+    let proxy_addr = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![proxy_addr]));
+    let app = make_rate_limit_router(config);
+
+    let via_proxy = peer([10, 0, 0, 1], 8080);
+
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(via_proxy, "1.2.3.4"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(via_proxy, "5.6.7.8"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::OK,
+        "distinct forwarded client IPs behind a trusted proxy must not share a bucket"
+    );
+}
+
+/// With trusted-proxy support enabled but the peer address NOT in the
+/// allowlist, `X-Forwarded-For` must still be ignored — untrusted peers
+/// cannot forge a fresh bucket even when trusted-proxy support is turned on
+/// for other peers.
+#[tokio::test]
+async fn test_rate_limit_untrusted_peer_ignores_forwarded_for_even_when_feature_enabled() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
+    let app = make_rate_limit_router(config);
+
+    let untrusted_peer = peer([203, 0, 113, 50], 9000);
+
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(untrusted_peer, "1.2.3.4"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(untrusted_peer, "5.6.7.8"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "untrusted peer must be keyed on its real address regardless of forwarded header"
+    );
+}
+
+/// A proxy configured in the allowlist as a plain IPv4 address must still be
+/// recognized when it arrives as the IPv4-mapped IPv6 address (typical of a
+/// dual-stack listener bound to `::`), otherwise the allowlist silently never
+/// matches and the deployment degrades into the single-shared-bucket fallback.
+#[tokio::test]
+async fn test_rate_limit_trusted_proxy_matches_ipv4_mapped_ipv6_peer() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
+    let app = make_rate_limit_router(config);
+
+    let mapped_peer = ConnectInfo(SocketAddr::new(
+        IpAddr::V6(Ipv4Addr::new(10, 0, 0, 1).to_ipv6_mapped()),
+        8080,
+    ));
+
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(mapped_peer, "1.2.3.4"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(mapped_peer, "5.6.7.8"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::OK,
+        "distinct forwarded client IPs behind an IPv4-mapped trusted proxy must not share a bucket"
+    );
+}
+
+/// `X-Forwarded-For` must be walked right-to-left: the client-supplied
+/// (leftmost) entry is attacker-controlled and must never determine the
+/// bucket, even when trusted-proxy support is enabled.
+#[tokio::test]
+async fn test_rate_limit_leftmost_forwarded_for_entry_is_ignored() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
+    let app = make_rate_limit_router(config);
+
+    let via_proxy = peer([198, 51, 100, 1], 443);
+
+    // Real client 192.0.2.1 (rightmost, appended by the trusted proxy); the
+    // leftmost entry is attacker-controlled and varies per request.
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(via_proxy, "9.9.9.9, 192.0.2.1"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(via_proxy, "8.8.8.8, 192.0.2.1"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "varying the leftmost (client-supplied) entry must not grant a fresh bucket"
+    );
+}
+
+/// A malformed rightmost `X-Forwarded-For` entry (e.g. Azure App Gateway's
+/// `<ip>:<port>` form) must fail the walk closed rather than being skipped
+/// in favor of a client-supplied entry further left — otherwise a client
+/// can forge the leftmost entry on every request and reopen the bypass.
+#[tokio::test]
+async fn test_rate_limit_malformed_rightmost_entry_fails_closed() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
+    let app = make_rate_limit_router(config);
+
+    let via_proxy = peer([198, 51, 100, 1], 443);
+
+    // Malformed (ip:port) rightmost entry; the leftmost entry varies per
+    // request and must NOT be picked up as the real client.
+    let resp1 = app
+        .clone()
+        .oneshot(request_from_peer(via_proxy, "1.1.1.1, 192.0.2.1:8080"))
+        .await
+        .unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let resp2 = app
+        .oneshot(request_from_peer(via_proxy, "2.2.2.2, 192.0.2.1:8080"))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a malformed rightmost entry must fail closed onto the trusted proxy's own peer \
+         address, not skip past it to a client-supplied entry"
+    );
+}
+
+/// Repeated `X-Forwarded-For` header lines (e.g. HAProxy's `option
+/// forwardfor`, which adds a new line rather than merging into an existing
+/// one) must be read as a single comma-joined list in line order — reading
+/// only the first line would let the client's own line hide the proxy's
+/// authoritative one.
+#[tokio::test]
+async fn test_rate_limit_reads_all_forwarded_for_header_lines() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
+    let config = RateLimitConfig::new(1)
+        .with_window(Duration::from_secs(60))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
+    let app = make_rate_limit_router(config);
+
+    let via_proxy = peer([198, 51, 100, 1], 443);
+
+    let mut req1 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    req1.extensions_mut().insert(via_proxy);
+    req1.headers_mut()
+        .append("X-Forwarded-For", "1.1.1.1".parse().unwrap());
+    req1.headers_mut()
+        .append("X-Forwarded-For", "192.0.2.1".parse().unwrap());
+
+    let resp1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    // Different client-supplied first line, same proxy-appended second line
+    // — must share the same bucket.
+    let mut req2 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    req2.extensions_mut().insert(via_proxy);
+    req2.headers_mut()
+        .append("X-Forwarded-For", "9.9.9.9".parse().unwrap());
+    req2.headers_mut()
+        .append("X-Forwarded-For", "192.0.2.1".parse().unwrap());
+
+    let resp2 = app.oneshot(req2).await.unwrap();
+    assert_eq!(
+        resp2.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "the proxy-appended second X-Forwarded-For line must be used, not just the first line"
     );
 }
 

--- a/crates/pjs-core/tests/http_rate_limiting_integration.rs
+++ b/crates/pjs-core/tests/http_rate_limiting_integration.rs
@@ -4,7 +4,9 @@
 // - RateLimitMiddleware with token bucket implementation
 // - 429 Too Many Requests response when limit exceeded
 // - X-RateLimit-* headers per RFC 6585
-// - Per-IP rate limiting
+// - Per-IP rate limiting keyed on the real TCP peer address (ConnectInfo)
+// - X-Forwarded-For/X-Real-IP are untrusted by default (#336); only consulted
+//   when TrustedProxyConfig explicitly allowlists the peer
 // - Concurrent request handling
 //
 // Coverage target: 100% for rate limiting integration
@@ -14,14 +16,19 @@
 use axum::{
     Router,
     body::Body,
-    extract::Request,
+    extract::{ConnectInfo, Request},
     http::{StatusCode, header},
     response::IntoResponse,
     routing::get,
 };
-use pjson_rs::infrastructure::http::{RateLimitConfig, RateLimitMiddleware};
+use pjson_rs::infrastructure::http::{RateLimitConfig, RateLimitMiddleware, TrustedProxyConfig};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tower::ServiceExt;
+
+fn peer(addr: [u8; 4], port: u16) -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::from((IpAddr::V4(Ipv4Addr::from(addr)), port)))
+}
 
 // ============================================================================
 // RateLimitConfig Tests
@@ -167,12 +174,16 @@ async fn test_rate_limit_headers_format() {
     assert!(reset.unwrap() > now);
 }
 
+/// Without a `ConnectInfo<SocketAddr>` extension (i.e. the router not served
+/// via `into_make_service_with_connect_info`), the real peer is unknown and
+/// every request falls back to the same key. `X-Forwarded-For` is never
+/// trusted by default (#336), so a *different* header value must not grant a
+/// fresh bucket.
 #[tokio::test]
-async fn test_rate_limit_extracts_ip_from_x_forwarded_for() {
+async fn test_rate_limit_ignores_x_forwarded_for_by_default() {
     let config = RateLimitConfig::new(2).with_window(Duration::from_millis(100));
     let app = create_test_router(config);
 
-    // Requests with same X-Forwarded-For should share rate limit
     for _ in 0..2 {
         let request = Request::builder()
             .uri("/test")
@@ -184,10 +195,10 @@ async fn test_rate_limit_extracts_ip_from_x_forwarded_for() {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    // Third request from same IP should be rate limited
+    // Different X-Forwarded-For value must NOT grant a fresh bucket.
     let request = Request::builder()
         .uri("/test")
-        .header("X-Forwarded-For", "192.168.1.100")
+        .header("X-Forwarded-For", "10.0.0.1")
         .body(Body::empty())
         .unwrap();
 
@@ -195,12 +206,12 @@ async fn test_rate_limit_extracts_ip_from_x_forwarded_for() {
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 }
 
+/// Same as above for `X-Real-IP` — never trusted by default.
 #[tokio::test]
-async fn test_rate_limit_extracts_ip_from_x_real_ip() {
+async fn test_rate_limit_ignores_x_real_ip_by_default() {
     let config = RateLimitConfig::new(2).with_window(Duration::from_millis(100));
     let app = create_test_router(config);
 
-    // Requests with same X-Real-IP should share rate limit
     for _ in 0..2 {
         let request = Request::builder()
             .uri("/test")
@@ -212,10 +223,10 @@ async fn test_rate_limit_extracts_ip_from_x_real_ip() {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
-    // Third request from same IP should be rate limited
+    // Different X-Real-IP value must NOT grant a fresh bucket.
     let request = Request::builder()
         .uri("/test")
-        .header("X-Real-IP", "10.0.0.50")
+        .header("X-Real-IP", "10.0.0.99")
         .body(Body::empty())
         .unwrap();
 
@@ -223,37 +234,29 @@ async fn test_rate_limit_extracts_ip_from_x_real_ip() {
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
 }
 
+/// Isolation must be keyed on the real TCP peer (`ConnectInfo`), not on any
+/// client-supplied header.
 #[tokio::test]
 async fn test_rate_limit_different_ips_isolated() {
     let config = RateLimitConfig::new(1).with_window(Duration::from_millis(100));
     let app = create_test_router(config);
 
-    // First IP uses its limit
-    let request1 = Request::builder()
-        .uri("/test")
-        .header("X-Forwarded-For", "192.168.1.1")
-        .body(Body::empty())
-        .unwrap();
+    let mut request1 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    request1.extensions_mut().insert(peer([192, 168, 1, 1], 1));
 
     let response1 = app.clone().oneshot(request1).await.unwrap();
     assert_eq!(response1.status(), StatusCode::OK);
 
-    // Second request from first IP should be rate limited
-    let request2 = Request::builder()
-        .uri("/test")
-        .header("X-Forwarded-For", "192.168.1.1")
-        .body(Body::empty())
-        .unwrap();
+    // Second request from the same peer should be rate limited
+    let mut request2 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    request2.extensions_mut().insert(peer([192, 168, 1, 1], 2));
 
     let response2 = app.clone().oneshot(request2).await.unwrap();
     assert_eq!(response2.status(), StatusCode::TOO_MANY_REQUESTS);
 
-    // Different IP should still work
-    let request3 = Request::builder()
-        .uri("/test")
-        .header("X-Forwarded-For", "192.168.1.2")
-        .body(Body::empty())
-        .unwrap();
+    // A different real peer should still work
+    let mut request3 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    request3.extensions_mut().insert(peer([192, 168, 1, 2], 1));
 
     let response3 = app.clone().oneshot(request3).await.unwrap();
     assert_eq!(response3.status(), StatusCode::OK);
@@ -316,33 +319,76 @@ async fn test_rate_limit_429_response_body() {
     assert!(body_str.contains("retry_after"));
 }
 
+/// `X-Forwarded-For` proxy-chain parsing walks right-to-left and keys on the
+/// rightmost entry that is not itself a trusted proxy — the entry appended
+/// by the closest trusted hop, which the client cannot forge. A client behind
+/// the trusted proxy varying the leftmost (client-supplied) entry on every
+/// request must NOT get a fresh bucket; that would be the exact #336 bypass
+/// reopened inside the opt-in trusted-proxy path.
 #[tokio::test]
-async fn test_rate_limit_x_forwarded_for_multiple_ips() {
-    let config = RateLimitConfig::new(2).with_window(Duration::from_millis(100));
+async fn test_rate_limit_x_forwarded_for_uses_rightmost_untrusted_entry() {
+    let trusted_proxy = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 200));
+    let config = RateLimitConfig::new(2)
+        .with_window(Duration::from_millis(100))
+        .with_trusted_proxies(TrustedProxyConfig::new(vec![trusted_proxy]));
     let app = create_test_router(config);
 
-    // X-Forwarded-For with multiple IPs (proxy chain)
-    // Should use the first IP in the chain
-    for _ in 0..2 {
-        let request = Request::builder()
-            .uri("/test")
-            .header("X-Forwarded-For", "203.0.113.1, 198.51.100.1, 192.0.2.1")
-            .body(Body::empty())
-            .unwrap();
+    // Same real client (rightmost entry, appended by the trusted proxy) but a
+    // different attacker-controlled leftmost entry each time — must still
+    // share the same bucket.
+    for spoofed in ["203.0.113.1", "10.10.10.10"] {
+        let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(peer([198, 51, 100, 200], 443));
+        request.headers_mut().insert(
+            "X-Forwarded-For",
+            format!("{spoofed}, 192.0.2.1").parse().unwrap(),
+        );
 
         let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "requests sharing the real (rightmost) client IP must share budget"
+        );
     }
 
-    // Third request should be rate limited (same first IP)
-    let request = Request::builder()
-        .uri("/test")
-        .header("X-Forwarded-For", "203.0.113.1, 198.51.100.99")
-        .body(Body::empty())
-        .unwrap();
+    // Budget of 2 is now exhausted by the real client 192.0.2.1. A third
+    // request with yet another spoofed leftmost entry but the same rightmost
+    // (real) client must still be rejected.
+    let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    request
+        .extensions_mut()
+        .insert(peer([198, 51, 100, 200], 443));
+    request
+        .headers_mut()
+        .insert("X-Forwarded-For", "1.2.3.4, 192.0.2.1".parse().unwrap());
 
     let response = app.clone().oneshot(request).await.unwrap();
-    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        response.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "leftmost spoofed entry must not grant a fresh rate-limit bucket"
+    );
+
+    // A genuinely different real client (different rightmost entry) must get
+    // an independent bucket.
+    let mut request2 = Request::builder().uri("/test").body(Body::empty()).unwrap();
+    request2
+        .extensions_mut()
+        .insert(peer([198, 51, 100, 200], 443));
+    request2.headers_mut().insert(
+        "X-Forwarded-For",
+        "203.0.113.1, 192.0.2.99".parse().unwrap(),
+    );
+
+    let response2 = app.clone().oneshot(request2).await.unwrap();
+    assert_eq!(
+        response2.status(),
+        StatusCode::OK,
+        "a different real (rightmost) client IP must not be throttled by another client's budget"
+    );
 }
 
 #[tokio::test]
@@ -376,15 +422,14 @@ async fn test_rate_limit_concurrent_requests_same_ip() {
 
     let mut handles = vec![];
 
-    // Send 10 concurrent requests from same IP
-    for _ in 0..10 {
+    // Send 10 concurrent requests from same real peer
+    for i in 0..10 {
         let app_clone = app.clone();
         let handle = tokio::spawn(async move {
-            let request = Request::builder()
-                .uri("/test")
-                .header("X-Forwarded-For", "192.168.1.100")
-                .body(Body::empty())
-                .unwrap();
+            let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+            request
+                .extensions_mut()
+                .insert(peer([192, 168, 1, 100], 1000 + i as u16));
 
             app_clone.oneshot(request).await.unwrap().status()
         });
@@ -416,18 +461,16 @@ async fn test_rate_limit_concurrent_requests_different_ips() {
 
     let mut handles = vec![];
 
-    // Send requests from 3 different IPs, 3 requests each
-    for ip_suffix in 1..=3 {
-        for _ in 0..3 {
+    // Send requests from 3 different real peers, 3 requests each
+    for ip_suffix in 1..=3u8 {
+        for req_num in 0..3u16 {
             let app_clone = app.clone();
-            let ip = format!("192.168.1.{}", ip_suffix);
 
             let handle = tokio::spawn(async move {
-                let request = Request::builder()
-                    .uri("/test")
-                    .header("X-Forwarded-For", ip)
-                    .body(Body::empty())
-                    .unwrap();
+                let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+                request
+                    .extensions_mut()
+                    .insert(peer([192, 168, 1, ip_suffix], 2000 + req_num));
 
                 (
                     ip_suffix,


### PR DESCRIPTION
## Summary

- Keys the HTTP rate limiter (`RateLimitMiddleware`) on the real TCP peer address via axum's `ConnectInfo<SocketAddr>` by default, closing a bypass where a client could send a fresh spoofed `X-Forwarded-For`/`X-Real-IP` value on every request to get a fresh rate-limit bucket and defeat the DoS-protection control entirely.
- Adds opt-in proxy-header support via `RateLimitConfig::with_trusted_proxies`: forwarded headers are only honored when the real peer is in an explicit allowlist. `X-Forwarded-For` is read across all header lines and parsed right-to-left, skipping trusted-proxy entries, and fails closed (falls back to `X-Real-IP`, then the peer) on the first unparseable entry — closing a re-opened bypass that surfaced during review for HAProxy-style multi-line headers and Azure Application Gateway's `ip:port` format.
- Canonicalizes IPv4-mapped IPv6 addresses on both sides of allowlist comparisons.
- Logs a one-time warning if a request has no `ConnectInfo` extension (router not served via `into_make_service_with_connect_info`), since that otherwise silently collapses every client onto one shared bucket.
- Removes two stale TODOs in `axum_adapter.rs` claiming authentication and HTTP rate limiting are unimplemented — both already exist (`ApiKeyAuthLayer`/`JwtAuthLayer`, `RateLimitMiddleware`) and are now documented in place instead.

Closes #336, closes #319.

Follow-up filed separately: #346 (HTTP rate limiter's client map is never pruned — pre-existing, orthogonal to this fix).

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (944/944)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New regression tests: spoofed-header bypass prevention, real-peer keying, opt-in trusted-proxy path (both trusted and untrusted peer), right-to-left `X-Forwarded-For` selection under a trusted proxy, multi-line `X-Forwarded-For` handling, fail-closed behavior on an unparseable rightmost entry
- [x] Went through two rounds of adversarial critique that found and confirmed the fix for a reintroduced bypass inside the trusted-proxy path itself before this PR was opened
