### PR TITLE
fix(pjson-rs)!: assign EventId at publish time, bound outgoing channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Removed stale TODO comments in `axum_adapter.rs` describing authentication and HTTP rate limiting as unimplemented; both already exist (`ApiKeyAuthLayer`/`JwtAuthLayer` in `infrastructure::http::auth`, `RateLimitMiddleware` in `infrastructure::http::middleware`) and are now documented and cross-referenced in place (#319)
+- `DomainEvent::event_id()` derived a content-hash-based UUID, so two structurally-identical events (same variant, session/stream ID, and timestamp) produced the same `EventId`. `InMemoryEventPublisher.event_log` keys solely on `EventId`, so colliding events silently overwrote each other with no error. `InMemoryEventPublisher` and `HttpEventPublisher` now mint a fresh `EventId::new()` per stored/published event at publish time, guaranteeing distinct identity even for structurally-identical events. `EventPublisherGat`'s doc now states this as the identity contract implementors must follow (#328)
+- Replace unbounded `mpsc` channels in the WebSocket server/client outgoing-message paths and `InMemoryEventPublisher::with_channel` with bounded channels (capacity 1000; a conservative default bounding message count, not queued bytes — see follow-up for a byte-size-aware bound), so a slow consumer can no longer cause unbounded memory growth. Call sites with a dedicated consumer task and no risk of stalling unrelated work (`PjsWebSocketClient::request_stream`) apply backpressure via `.send().await`; best-effort control-path sends that must not stall their own read loop (WebSocket server `send_frame`, client frame-ack/pong replies, event-publisher streaming channel) use `try_send` and drop-and-log on a full channel instead (#314)
+
+### Removed
+
+- **BREAKING** `DomainEvent::event_id()` (public on `pjson-rs`/`pjson-rs-domain`). It derived identity from a content hash, which is exactly the bug behind #328's silent event-log collisions; there is no drop-in replacement because identity is no longer a property of `DomainEvent` itself — see the `Fixed` entry above for where identity is now assigned. Pre-1.0 breaking change; no deprecation cycle (#328)
 
 ### CI
 

--- a/crates/pjs-core/src/domain/ports/gat.rs
+++ b/crates/pjs-core/src/domain/ports/gat.rs
@@ -193,6 +193,17 @@ gat_port! {
     /// Zero-cost event publisher with GAT futures
     ///
     /// Publishes domain events for system integration.
+    ///
+    /// # Identity contract
+    ///
+    /// [`DomainEvent`] carries no identity of its own. An implementor that
+    /// stores or forwards events under a unique key (e.g. as
+    /// [`InMemoryEventPublisher`](crate::infrastructure::adapters::event_publisher::InMemoryEventPublisher)
+    /// does with `StoredEvent`) is responsible for minting a fresh
+    /// [`EventId::new`](crate::domain::events::EventId::new) at publish
+    /// time. Do not derive identity from event content (e.g. hashing a
+    /// `Debug` representation): structurally-identical events are
+    /// indistinguishable by content and will collide.
     pub trait EventPublisherGat {
         /// Publish a single domain event
         async fn publish(&self, event: DomainEvent) -> ();

--- a/crates/pjs-core/src/infrastructure/adapters/event_publisher.rs
+++ b/crates/pjs-core/src/infrastructure/adapters/event_publisher.rs
@@ -20,6 +20,16 @@ use crate::domain::{
 type NotificationId = u64;
 type NotificationCallback = Arc<dyn Fn(&DomainEvent) + Send + Sync>;
 
+/// Capacity of the streaming channel returned by [`InMemoryEventPublisher::with_channel`].
+///
+/// Gives `publish`/`publish_batch` room to absorb bursts before a full
+/// channel starts dropping events (logged via [`mpsc::error::TrySendError`]
+/// rather than blocking the publish hot path — see [`EventPublisherGat`]'s
+/// doc). 1000 is a conservative default chosen without a specific
+/// throughput target; sizing it from an expected consumer lag or event
+/// rate is tracked as a follow-up.
+const EVENT_CHANNEL_CAPACITY: usize = 1000;
+
 /// In-memory event publisher with subscription support
 pub struct InMemoryEventPublisher {
     /// Lock-free notification callbacks using DashMap
@@ -29,7 +39,7 @@ pub struct InMemoryEventPublisher {
     /// Next notification ID generator
     next_notification_id: Arc<AtomicU64>,
     /// Optional channel for streaming events
-    channel_tx: Arc<tokio::sync::RwLock<Option<mpsc::UnboundedSender<StoredEvent>>>>,
+    channel_tx: Arc<tokio::sync::RwLock<Option<mpsc::Sender<StoredEvent>>>>,
 }
 
 impl Clone for InMemoryEventPublisher {
@@ -46,7 +56,11 @@ impl Clone for InMemoryEventPublisher {
 /// Event recorded by [`InMemoryEventPublisher`] for inspection and replay.
 #[derive(Debug, Clone)]
 pub struct StoredEvent {
-    /// Identifier of the originating domain event.
+    /// Surrogate key minted with [`EventId::new`] when this record is
+    /// stored/published. `DomainEvent` itself carries no identity, so this
+    /// id does not correlate across independently-stored copies of "the
+    /// same" event (e.g. each destination in [`CompositeEventPublisher`]
+    /// mints its own).
     pub id: EventId,
     /// Stringified event-type discriminant.
     pub event_type: String,
@@ -70,8 +84,8 @@ impl InMemoryEventPublisher {
     }
 
     /// Initialize event streaming channel (lock-free)
-    pub fn with_channel() -> (Self, mpsc::UnboundedReceiver<StoredEvent>) {
-        let (tx, rx) = mpsc::unbounded_channel();
+    pub fn with_channel() -> (Self, mpsc::Receiver<StoredEvent>) {
+        let (tx, rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
         let publisher = Self {
             notification_callbacks: Arc::new(DashMap::new()),
             event_log: Arc::new(DashMap::new()),
@@ -168,7 +182,7 @@ impl EventPublisherGat for InMemoryEventPublisher {
     fn publish(&self, event: DomainEvent) -> Self::PublishFuture<'_> {
         async move {
             let stored_event = StoredEvent {
-                id: event.event_id(),
+                id: EventId::new(),
                 event_type: event.event_type().to_string(),
                 session_id: Some(event.session_id()),
                 timestamp: event.occurred_at(),
@@ -195,9 +209,14 @@ impl EventPublisherGat for InMemoryEventPublisher {
                 }
             }
 
-            // Send to channel if configured (lock-free check)
-            if let Some(tx) = self.channel_tx.read().await.as_ref() {
-                let _ = tx.send(stored_event);
+            // Send to channel if configured. `try_send` keeps this hot path
+            // non-blocking: a stalled consumer must not stall unrelated
+            // event publishing, so a full channel drops the event and logs
+            // rather than awaiting capacity.
+            if let Some(tx) = self.channel_tx.read().await.as_ref()
+                && let Err(e) = tx.try_send(stored_event)
+            {
+                tracing::warn!("Dropping event from streaming channel: {e}");
             }
 
             // Notify callbacks (lock-free iteration)
@@ -217,7 +236,7 @@ impl EventPublisherGat for InMemoryEventPublisher {
                 .into_par_iter()
                 .map(|event| {
                     let stored_event = StoredEvent {
-                        id: event.event_id(),
+                        id: EventId::new(),
                         event_type: event.event_type().to_string(),
                         session_id: Some(event.session_id()),
                         timestamp: event.occurred_at(),
@@ -238,10 +257,14 @@ impl EventPublisherGat for InMemoryEventPublisher {
                 })
                 .collect();
 
-            // Send to channel if configured (sequential for channel ordering)
+            // Send to channel if configured (sequential for channel ordering).
+            // Same non-blocking `try_send` policy as `publish`: drop and log
+            // on a full channel instead of stalling the batch.
             if let Some(tx) = self.channel_tx.read().await.as_ref() {
                 for stored_event in stored_events {
-                    let _ = tx.send(stored_event);
+                    if let Err(e) = tx.try_send(stored_event) {
+                        tracing::warn!("Dropping event from streaming channel: {e}");
+                    }
                 }
             }
 
@@ -306,7 +329,7 @@ impl EventPublisherGat for HttpEventPublisher {
     fn publish(&self, event: DomainEvent) -> Self::PublishFuture<'_> {
         async move {
             let payload = serde_json::json!({
-                "event_id": event.event_id().to_string(),
+                "event_id": EventId::new().to_string(),
                 "event_type": event.event_type(),
                 "session_id": event.session_id().to_string(),
                 "occurred_at": event.occurred_at(),
@@ -349,7 +372,7 @@ impl EventPublisherGat for HttpEventPublisher {
                 .iter()
                 .map(|event| {
                     serde_json::json!({
-                        "event_id": event.event_id().to_string(),
+                        "event_id": EventId::new().to_string(),
                         "event_type": event.event_type(),
                         "session_id": event.session_id().to_string(),
                         "occurred_at": event.occurred_at(),
@@ -601,6 +624,119 @@ mod tests {
         publisher.publish_batch(events).await.unwrap();
 
         assert_eq!(publisher.event_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_structurally_identical_events_do_not_collide() {
+        // Regression test for #328: EventId used to be derived from the
+        // event's `Debug` content hash, so two structurally-identical
+        // events (same variant, session_id, and timestamp) produced the
+        // same EventId and silently overwrote each other in `event_log`.
+        let publisher = InMemoryEventPublisher::new();
+        let session_id = SessionId::new();
+        let timestamp = chrono::Utc::now();
+
+        let event1 = DomainEvent::SessionActivated {
+            session_id,
+            timestamp,
+        };
+        let event2 = DomainEvent::SessionActivated {
+            session_id,
+            timestamp,
+        };
+        assert_eq!(
+            format!("{event1:?}"),
+            format!("{event2:?}"),
+            "events must be structurally identical for this regression test to be meaningful"
+        );
+
+        publisher.publish(event1).await.unwrap();
+        publisher.publish(event2).await.unwrap();
+
+        assert_eq!(
+            publisher.event_count(),
+            2,
+            "both events must be stored under distinct EventIds, not overwrite each other"
+        );
+
+        let stored = publisher.events_for_session(session_id);
+        assert_eq!(stored.len(), 2);
+        assert_ne!(
+            stored[0].id, stored[1].id,
+            "structurally identical events must still get distinct EventIds"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_channel_is_bounded() {
+        // Regression test for #314: `with_channel` used to return an
+        // unbounded channel. It must now be capped at `EVENT_CHANNEL_CAPACITY`.
+        let (publisher, _rx) = InMemoryEventPublisher::with_channel();
+        let tx = publisher
+            .channel_tx
+            .read()
+            .await
+            .clone()
+            .expect("with_channel must configure a sender");
+        assert_eq!(tx.max_capacity(), EVENT_CHANNEL_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn test_publish_does_not_block_when_streaming_channel_is_full() {
+        // Regression test for #314: once the streaming channel is full,
+        // `publish` must drop-and-log via `try_send` rather than blocking
+        // on a stalled consumer. This asserts the drop actually happens
+        // (not just that `publish` returns quickly): `event_log` holds
+        // every event regardless, so the channel itself must be checked
+        // directly to prove the overflow event was dropped rather than
+        // queued.
+        let (publisher, mut rx) = InMemoryEventPublisher::with_channel();
+        let session_id = SessionId::new();
+
+        for _ in 0..EVENT_CHANNEL_CAPACITY {
+            let event = DomainEvent::SessionActivated {
+                session_id,
+                timestamp: chrono::Utc::now(),
+            };
+            publisher.publish(event).await.unwrap();
+        }
+
+        // The channel must now be completely full.
+        assert_eq!(
+            publisher
+                .channel_tx
+                .read()
+                .await
+                .as_ref()
+                .expect("with_channel must configure a sender")
+                .capacity(),
+            0,
+            "channel should be at capacity after publishing EVENT_CHANNEL_CAPACITY events"
+        );
+
+        let event = DomainEvent::SessionActivated {
+            session_id,
+            timestamp: chrono::Utc::now(),
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(2), publisher.publish(event))
+            .await
+            .expect("publish must not block when the streaming channel is full")
+            .unwrap();
+
+        // event_log stores every event regardless of channel state.
+        assert_eq!(publisher.event_count(), EVENT_CHANNEL_CAPACITY + 1);
+
+        // But the channel itself must hold only the events that fit before
+        // it filled up: the overflow event was dropped, not queued.
+        rx.close();
+        let mut drained = 0;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(
+            drained, EVENT_CHANNEL_CAPACITY,
+            "the overflow event must have been dropped from the channel, not queued"
+        );
     }
 
     #[tokio::test]

--- a/crates/pjs-core/src/infrastructure/websocket/client.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/client.rs
@@ -15,12 +15,20 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, error, info, warn};
 use url::Url;
 
+/// Capacity of the client's outgoing message channel.
+///
+/// Bounds how many outgoing messages (stream requests, acks, pongs) can
+/// queue while `send_task` catches up. 1000 is a conservative default, not
+/// a byte-size bound (see the equivalent constant in `websocket::server`
+/// for the same caveat and the tracked follow-up).
+const MESSAGE_QUEUE_CAPACITY: usize = 1000;
+
 /// WebSocket client for receiving PJS streams
 pub struct PjsWebSocketClient {
     url: Url,
     sessions: Arc<RwLock<HashMap<String, ClientStreamSession>>>,
-    message_tx: mpsc::UnboundedSender<WsMessage>,
-    message_rx: Arc<RwLock<Option<mpsc::UnboundedReceiver<WsMessage>>>>,
+    message_tx: mpsc::Sender<WsMessage>,
+    message_rx: Arc<RwLock<Option<mpsc::Receiver<WsMessage>>>>,
 }
 
 /// Client-side stream session
@@ -45,7 +53,7 @@ impl PjsWebSocketClient {
     pub fn new(url: impl AsRef<str>) -> PjsResult<Self> {
         let url = Url::parse(url.as_ref()).map_err(|e| PjsError::InvalidUrl(e.to_string()))?;
 
-        let (message_tx, message_rx) = mpsc::unbounded_channel();
+        let (message_tx, message_rx) = mpsc::channel(MESSAGE_QUEUE_CAPACITY);
 
         Ok(Self {
             url,
@@ -171,6 +179,7 @@ impl PjsWebSocketClient {
 
         self.message_tx
             .send(message)
+            .await
             .map_err(|e| PjsError::ClientError(format!("Failed to send stream request: {e}")))?;
 
         // Initialize session tracking
@@ -247,7 +256,7 @@ impl PjsWebSocketClient {
 
     async fn handle_incoming_message(
         sessions: Arc<RwLock<HashMap<String, ClientStreamSession>>>,
-        message_tx: mpsc::UnboundedSender<WsMessage>,
+        message_tx: mpsc::Sender<WsMessage>,
         message: WsMessage,
     ) -> PjsResult<()> {
         match message {
@@ -296,8 +305,16 @@ impl PjsWebSocketClient {
                     processing_time_ms: processing_time.as_millis() as u64,
                 };
 
-                if let Err(e) = message_tx.send(ack_message) {
-                    warn!("Failed to send frame acknowledgment: {}", e);
+                // Best-effort: `handle_incoming_message` runs inline inside
+                // `receive_task`'s read loop, so awaiting a full channel here
+                // would stop draining the socket and stall the connection.
+                // Dropping an ack is recoverable (the server can re-send or
+                // time out the frame); stalling the whole read loop is not.
+                if let Err(e) = message_tx.try_send(ack_message) {
+                    warn!(
+                        "Dropping frame acknowledgment (channel full or closed): {}",
+                        e
+                    );
                 }
             }
             WsMessage::StreamComplete {
@@ -324,8 +341,10 @@ impl PjsWebSocketClient {
             WsMessage::Ping { timestamp } => {
                 debug!("Received ping with timestamp: {}", timestamp);
                 let pong = WsMessage::Pong { timestamp };
-                if let Err(e) = message_tx.send(pong) {
-                    warn!("Failed to send pong: {}", e);
+                // Same rationale as the ack above: best-effort, must not
+                // stall the read loop by awaiting a full channel.
+                if let Err(e) = message_tx.try_send(pong) {
+                    warn!("Dropping pong (channel full or closed): {}", e);
                 }
             }
             WsMessage::Pong { timestamp } => {
@@ -392,6 +411,27 @@ mod tests {
 
         let sessions = client.sessions.read().await;
         assert!(sessions.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn test_message_channel_is_bounded() {
+        // Regression test for #314: the client's outgoing message channel
+        // used to be unbounded, so a stalled `send_task` let it grow
+        // without limit. It must now reject sends once
+        // `MESSAGE_QUEUE_CAPACITY` is reached.
+        let client = PjsWebSocketClient::new("ws://localhost:3001/ws").unwrap();
+        let tx = client.message_tx.clone();
+
+        for _ in 0..MESSAGE_QUEUE_CAPACITY {
+            tx.try_send(WsMessage::Pong { timestamp: 0 })
+                .expect("channel should accept sends up to its capacity");
+        }
+
+        let result = tx.try_send(WsMessage::Pong { timestamp: 0 });
+        assert!(
+            matches!(result, Err(mpsc::error::TrySendError::Full(_))),
+            "channel must reject sends past capacity instead of growing unbounded"
+        );
     }
 
     #[test]

--- a/crates/pjs-core/src/infrastructure/websocket/mod.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/mod.rs
@@ -232,6 +232,14 @@ pub trait WebSocketTransport: Send + Sync {
     ) -> Self::StartStreamFuture<'_>;
 
     /// Send frame to client
+    ///
+    /// Implementors typically queue `message` onto a per-connection channel
+    /// consumed by that same connection's I/O loop. Do not call this method
+    /// from within that connection's own message-handling path (e.g. from
+    /// [`WebSocketTransport::handle_message`]): if the implementor applies
+    /// backpressure by awaiting channel capacity rather than dropping,
+    /// calling from the same loop that drains the channel can deadlock the
+    /// connection.
     fn send_frame(
         &self,
         connection: Arc<Self::Connection>,

--- a/crates/pjs-core/src/infrastructure/websocket/server.rs
+++ b/crates/pjs-core/src/infrastructure/websocket/server.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "http-server")]
 use super::{AdaptiveStreamController, StreamOptions, WebSocketTransport, WsMessage};
 use crate::{
-    Error as PjsError, Result as PjsResult,
+    Result as PjsResult,
     security::{RateLimitConfig, RateLimitGuard, WebSocketRateLimiter},
 };
 #[cfg(feature = "http-server")]
@@ -23,9 +23,21 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::sync::broadcast::error::RecvError;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info, warn};
 use uuid;
+
+/// Capacity of each per-connection outgoing message channel.
+///
+/// Bounds how many frames can queue for a slow client before `send_frame`
+/// drops further frames rather than growing memory without limit (see
+/// `send_frame`'s doc for why it drops instead of awaiting capacity).
+/// 1000 is a conservative default, not a byte-size bound: at the maximum
+/// configured WebSocket frame size, a fully-queued connection can still
+/// hold a large amount of memory. Sizing this from configured frame-size
+/// limits, or tracking queued bytes instead of message count, is tracked
+/// as a follow-up.
+const OUTGOING_QUEUE_CAPACITY: usize = 1000;
 
 /// Axum WebSocket transport implementation
 pub struct AxumWebSocketTransport {
@@ -33,7 +45,7 @@ pub struct AxumWebSocketTransport {
     /// Active connection IDs for tracking open sockets
     active_connections: Arc<RwLock<Vec<String>>>,
     /// Per-connection outgoing senders; keyed by connection ID
-    outgoing_channels: Arc<RwLock<HashMap<String, UnboundedSender<WsMessage>>>>,
+    outgoing_channels: Arc<RwLock<HashMap<String, Sender<WsMessage>>>>,
     /// Per-IP rate limiter applied to upgrade requests, connection establishment,
     /// and inbound application-level messages.
     rate_limiter: Arc<WebSocketRateLimiter>,
@@ -115,7 +127,8 @@ impl AxumWebSocketTransport {
         let frame_rx = self.controller.subscribe_frames();
 
         // Create channel for sending outgoing messages to this connection
-        let (outgoing_tx, mut outgoing_rx) = tokio::sync::mpsc::unbounded_channel::<WsMessage>();
+        let (outgoing_tx, mut outgoing_rx) =
+            tokio::sync::mpsc::channel::<WsMessage>(OUTGOING_QUEUE_CAPACITY);
         self.outgoing_channels
             .write()
             .await
@@ -360,16 +373,38 @@ impl WebSocketTransport for AxumWebSocketTransport {
         }
     }
 
+    /// The channel this queues onto is drained by the same `tokio::select!`
+    /// loop in [`Self::handle_socket`] that also awaits
+    /// `handle_websocket_message` inline. Calling `send_frame` from
+    /// within that inline handling path (directly or transitively) would
+    /// deadlock the connection: the loop can't reach `outgoing_rx.recv()`
+    /// again until the in-flight branch finishes, so a blocking send would
+    /// wait forever on a receiver that can't run. Using `try_send` here
+    /// keeps that latent hazard from becoming a real deadlock — see
+    /// `WebSocketTransport::send_frame`'s doc for the general contract.
     fn send_frame(
         &self,
         connection: Arc<Self::Connection>,
         message: WsMessage,
     ) -> Self::SendFrameFuture<'_> {
         async move {
-            let channels = self.outgoing_channels.read().await;
-            if let Some(tx) = channels.get(connection.as_ref()) {
-                tx.send(message)
-                    .map_err(|e| PjsError::Other(format!("Failed to queue frame: {}", e)))?;
+            // Clone the sender and release the read lock before sending:
+            // a stalled consumer must not hold up other connections
+            // waiting on `outgoing_channels` (e.g. cleanup taking the write lock).
+            let tx = self
+                .outgoing_channels
+                .read()
+                .await
+                .get(connection.as_ref())
+                .cloned();
+            if let Some(tx) = tx {
+                if let Err(e) = tx.try_send(message) {
+                    warn!(
+                        "send_frame: dropping frame for connection {} (channel full or closed): {}",
+                        connection.as_ref(),
+                        e
+                    );
+                }
             } else {
                 warn!(
                     "send_frame: no outgoing channel for connection {}",
@@ -476,5 +511,77 @@ mod tests {
             .start_streaming(&session_id)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_outgoing_channel_is_bounded() {
+        // Regression test for #314: the per-connection outgoing channel
+        // used to be unbounded, so a stalled consumer let it grow without
+        // limit. It must now reject sends once `OUTGOING_QUEUE_CAPACITY`
+        // is reached instead of growing memory indefinitely.
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<WsMessage>(OUTGOING_QUEUE_CAPACITY);
+
+        for _ in 0..OUTGOING_QUEUE_CAPACITY {
+            tx.try_send(WsMessage::Ping { timestamp: 0 })
+                .expect("channel should accept sends up to its capacity");
+        }
+
+        let result = tx.try_send(WsMessage::Ping { timestamp: 0 });
+        assert!(
+            matches!(result, Err(tokio::sync::mpsc::error::TrySendError::Full(_))),
+            "channel must reject sends past capacity instead of growing unbounded"
+        );
+
+        // Draining a slot frees capacity again — this is the flow-control
+        // behavior an unbounded channel could never provide.
+        rx.recv().await.expect("receiver should still be open");
+        tx.try_send(WsMessage::Ping { timestamp: 0 })
+            .expect("channel should accept a send after capacity is freed");
+    }
+
+    #[tokio::test]
+    async fn test_send_frame_drops_on_full_channel_without_blocking() {
+        // Regression test for S3: exercises the real `send_frame` code
+        // path (registered channel + read-lock clone) rather than an
+        // isolated mpsc channel, proving that a full outgoing channel
+        // makes `send_frame` drop-and-log via `try_send` instead of
+        // blocking. `try_send` never awaits, so it also makes the earlier
+        // deadlock hazard (this connection's own loop being both the
+        // sender and the only consumer) moot; the sender is still cloned
+        // out of the lock before sending for lock hygiene.
+        let transport = AxumWebSocketTransport::new();
+        let connection_id = "test-connection".to_string();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<WsMessage>(OUTGOING_QUEUE_CAPACITY);
+        transport
+            .outgoing_channels
+            .write()
+            .await
+            .insert(connection_id.clone(), tx);
+
+        let connection = Arc::new(connection_id);
+        for _ in 0..OUTGOING_QUEUE_CAPACITY {
+            transport
+                .send_frame(connection.clone(), WsMessage::Ping { timestamp: 0 })
+                .await
+                .expect("send_frame should accept sends up to channel capacity");
+        }
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            transport.send_frame(connection.clone(), WsMessage::Ping { timestamp: 0 }),
+        )
+        .await
+        .expect("send_frame must not block when the outgoing channel is full")
+        .expect("send_frame must return Ok even when dropping the overflow frame");
+
+        rx.close();
+        let mut drained = 0;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(
+            drained, OUTGOING_QUEUE_CAPACITY,
+            "the overflow frame must have been dropped, not queued"
+        );
     }
 }

--- a/crates/pjs-domain/src/events/mod.rs
+++ b/crates/pjs-domain/src/events/mod.rs
@@ -814,37 +814,6 @@ pub trait EventSubscriber {
 
 /// Extension methods for DomainEvent
 impl DomainEvent {
-    /// Get event ID for tracking (generated if not exists)
-    pub fn event_id(&self) -> EventId {
-        // For now, generate deterministic ID based on event content
-        // In future versions, this should be stored with the event
-        let content = format!("{self:?}");
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-        let mut hash = DefaultHasher::new();
-        content.hash(&mut hash);
-        let hash_val = hash.finish();
-        let uuid = uuid::Uuid::from_bytes([
-            (hash_val >> 56) as u8,
-            (hash_val >> 48) as u8,
-            (hash_val >> 40) as u8,
-            (hash_val >> 32) as u8,
-            (hash_val >> 24) as u8,
-            (hash_val >> 16) as u8,
-            (hash_val >> 8) as u8,
-            hash_val as u8,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        ]);
-        EventId::from_uuid(uuid)
-    }
-
     /// Get event timestamp
     pub fn occurred_at(&self) -> DateTime<Utc> {
         match self {

--- a/crates/pjs-domain/tests/events_comprehensive.rs
+++ b/crates/pjs-domain/tests/events_comprehensive.rs
@@ -302,36 +302,6 @@ mod event_metadata_tests {
     use super::*;
 
     #[test]
-    fn test_event_id_generation() {
-        let session_id = SessionId::new();
-        let timestamp = Utc::now();
-
-        let event = DomainEvent::SessionActivated {
-            session_id,
-            timestamp,
-        };
-
-        let event_id = event.event_id();
-        let event_id_str = event_id.to_string();
-        assert!(!event_id_str.is_empty());
-    }
-
-    #[test]
-    fn test_event_id_consistency() {
-        let session_id = SessionId::new();
-        let timestamp = Utc::now();
-
-        let event = DomainEvent::SessionActivated {
-            session_id,
-            timestamp,
-        };
-
-        let id1 = event.event_id();
-        let id2 = event.event_id();
-        assert_eq!(id1, id2); // Should be deterministic
-    }
-
-    #[test]
     fn test_occurred_at() {
         let session_id = SessionId::new();
         let timestamp = Utc::now();


### PR DESCRIPTION
## Summary

- `DomainEvent::event_id()` derived identity from a content hash, so two structurally-identical events (same variant, session/stream ID, timestamp) produced the same `EventId`. `InMemoryEventPublisher.event_log` keys solely on `EventId`, so colliding events silently overwrote each other with no error surfaced. `InMemoryEventPublisher` and `HttpEventPublisher` now mint a fresh `EventId::new()` per event at publish time; `EventPublisherGat`'s doc now states this as the identity contract implementors must follow.
- Unbounded `mpsc` channels in the WebSocket server/client outgoing-message paths and `InMemoryEventPublisher::with_channel` are now bounded (capacity 1000), preventing unbounded memory growth from a slow consumer. Call sites with a dedicated consumer task apply backpressure via `.send().await`; best-effort control-path sends that must not stall their own read loop (`send_frame`, client ack/pong replies, event-publisher streaming channel) use `try_send` with drop-and-log on a full channel.
- **BREAKING**: `DomainEvent::event_id()` is removed (pre-1.0, no deprecation cycle). No drop-in replacement — identity is no longer a property of `DomainEvent` itself; see the publisher-level `EventId::new()` assignment instead.

Closes #328, closes #314

## Notes

- Channel capacity (1000) bounds message *count*, not bytes — worst-case per-connection memory is still large at max frame size. Filed as follow-up: #349.
- `InMemoryEventPublisher.event_log`'s eviction-at-capacity policy (arbitrary `DashMap` iteration order, not oldest-first) is a pre-existing issue that now triggers sooner since events no longer collide/dedupe by accident. Filed as follow-up: #350.
- Went through an internal adversarial-critic pass that caught two deadlock-risk issues in the first draft (blocking sends on the now-bounded channels in code paths sharing a single-consumer event loop) — both fixed by switching those specific call sites to `try_send`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --all-targets` (2570/2570 passed, 3 skipped)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjson-rs -p pjson-rs-domain`
- [x] New regression test: two structurally-identical `DomainEvent`s get distinct `EventId`s and both survive in `event_log`
- [x] New/strengthened tests for bounded-channel backpressure and drop-and-log behavior on all three touched channels