### PR TITLE
fix(pjs-js-client): fix WASM initialization bugs and add typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,47 @@ jobs:
           node example.js | grep -q "Example 1: Basic Usage" || (echo "Example failed" && exit 1)
           node example.js | grep -q "Generated" || (echo "No frame generation detected" && exit 1)
 
+  # pjs-js-client ships a fallback ambient `declare module 'pjs-wasm'` (see
+  # src/types/pjs-wasm.d.ts) so `js-client-test`'s typecheck stays green when
+  # pjs-wasm/pkg hasn't been built. TypeScript resolves ambient module
+  # declarations before node_modules, so that shim always wins there and the
+  # real generated pjs_wasm.d.ts is never consulted by that job — this job
+  # excludes the shim and runs with the real, built package so a rename or
+  # signature change in crates/pjs-wasm's public API (semver-governed, see
+  # CLAUDE.md) still fails CI instead of passing silently.
+  wasm-types-drift:
+    name: WASM Types Drift Check
+    needs: [changes, wasm-build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: |
+      needs.changes.outputs.wasm == 'true' ||
+      needs.changes.outputs.js == 'true' ||
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: wasm-build-web
+          path: crates/pjs-wasm/pkg
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: crates/pjs-js-client/package-lock.json
+
+      - name: Install dependencies
+        working-directory: crates/pjs-js-client
+        run: npm ci
+
+      - name: Type check against the real pjs-wasm bindings
+        working-directory: crates/pjs-js-client
+        run: npm run typecheck:wasm-drift
+
   wasm-package-validation:
     name: NPM Package Validation
     needs: [changes, wasm-build]
@@ -603,6 +644,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 
@@ -622,6 +666,7 @@ jobs:
       - wasm-build
       - wasm-bundle-size
       - wasm-node-example
+      - wasm-types-drift
       - wasm-package-validation
       - security-osv
       - js-client-test
@@ -646,6 +691,7 @@ jobs:
           check wasm-build                "${{ needs.wasm-build.result }}"
           check wasm-bundle-size          "${{ needs.wasm-bundle-size.result }}"
           check wasm-node-example         "${{ needs.wasm-node-example.result }}"
+          check wasm-types-drift          "${{ needs.wasm-types-drift.result }}"
           check wasm-package-validation   "${{ needs.wasm-package-validation.result }}"
           check security-osv              "${{ needs.security-osv.result }}"
           check js-client-test            "${{ needs.js-client-test.result }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed stale TODO comments in `axum_adapter.rs` describing authentication and HTTP rate limiting as unimplemented; both already exist (`ApiKeyAuthLayer`/`JwtAuthLayer` in `infrastructure::http::auth`, `RateLimitMiddleware` in `infrastructure::http::middleware`) and are now documented and cross-referenced in place (#319)
 - `DomainEvent::event_id()` derived a content-hash-based UUID, so two structurally-identical events (same variant, session/stream ID, and timestamp) produced the same `EventId`. `InMemoryEventPublisher.event_log` keys solely on `EventId`, so colliding events silently overwrote each other with no error. `InMemoryEventPublisher` and `HttpEventPublisher` now mint a fresh `EventId::new()` per stored/published event at publish time, guaranteeing distinct identity even for structurally-identical events. `EventPublisherGat`'s doc now states this as the identity contract implementors must follow (#328)
 - Replace unbounded `mpsc` channels in the WebSocket server/client outgoing-message paths and `InMemoryEventPublisher::with_channel` with bounded channels (capacity 1000; a conservative default bounding message count, not queued bytes — see follow-up for a byte-size-aware bound), so a slow consumer can no longer cause unbounded memory growth. Call sites with a dedicated consumer task and no risk of stalling unrelated work (`PjsWebSocketClient::request_stream`) apply backpressure via `.send().await`; best-effort control-path sends that must not stall their own read loop (WebSocket server `send_frame`, client frame-ack/pong replies, event-publisher streaming channel) use `try_send` and drop-and-log on a full channel instead (#314)
+- `pjs-js-client`: `WasmParser.stream()` threw immediately with `TypeError: Cannot destructure property 'PriorityStream' of 'this.wasmModule' as it is undefined` because `initialize()` never assigned the imported `pjs-wasm` module to the instance (#338)
+- `pjs-js-client`: `WasmBackend.connect()` always failed in Node.js with a misleading `Failed to initialize WASM backend` error, because the generated `pjs-wasm` init function defaults to `fetch()`-ing the `.wasm` binary, and Node's `fetch` cannot load `file:` URLs. The WASM loader now detects Node.js and reads the `.wasm` binary from disk instead (#317)
 
 ### Removed
 
 - **BREAKING** `DomainEvent::event_id()` (public on `pjson-rs`/`pjson-rs-domain`). It derived identity from a content hash, which is exactly the bug behind #328's silent event-log collisions; there is no drop-in replacement because identity is no longer a property of `DomainEvent` itself — see the `Fixed` entry above for where identity is now assigned. Pre-1.0 breaking change; no deprecation cycle (#328)
 
+### Changed
+
+- `pjs-js-client`: `WasmBackend`'s synthetic `Complete` frame now reports `priority: Priority.Background` (10) instead of the previously hardcoded `1`, which was not a valid `Priority` enum member. This is a disclosed value change on that frame's `priority` field for consumers reading it directly; nothing in `pjs-js-client` itself gates behavior on it
+- `pjs-js-client`: `StreamStats.priorityDistribution` is now typed `Partial<Record<Priority, number>>` instead of `Record<Priority, number>` — the previous type was unsound (only priorities actually seen are ever populated) and could not be satisfied by an empty initial value. TypeScript consumers indexing this field now get `number | undefined`
+
 ### CI
 
 - Exclude `pjs-wasm` from the `--workspace` build/doctest steps on `build` and `doctest` jobs. Its transitive `web-sys` dependency declares ~1800 features; Cargo's auto-generated `--check-cfg` argument for it exceeds Windows' command-line length limit and crashed `sccache` on `windows-latest` (`os error 206`), intermittently blocking merges. `pjs-wasm`'s tests are all gated to `target_arch = "wasm32"` and its rustdoc examples are JS-only, so nothing was actually being exercised natively (#344)
+- Run `npm run typecheck` in the `js-client-test` job before `npm test`, so `pjs-js-client` type errors fail CI instead of going unnoticed (#339)
+- Add a `wasm-types-drift` CI job that type-checks `pjs-js-client` against the real, built `pjs-wasm` bindings (excluding the fallback ambient `pjs-wasm` type shim `js-client-test` relies on when the package isn't built), so a breaking rename or signature change in `crates/pjs-wasm`'s public API is caught instead of silently passing behind the shim
 
 ## [0.6.2] - 2026-07-27
 

--- a/crates/pjs-js-client/package-lock.json
+++ b/crates/pjs-js-client/package-lock.json
@@ -46,7 +46,7 @@
     },
     "../pjs-wasm/pkg": {
       "name": "pjs-wasm",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT OR Apache-2.0",
       "optional": true
     },

--- a/crates/pjs-js-client/package.json
+++ b/crates/pjs-js-client/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "typecheck": "tsc --noEmit",
+    "typecheck:wasm-drift": "tsc --noEmit -p tsconfig.wasm-drift.json",
     "dev": "concurrently \"npm run build:watch\" \"npm run test:watch\"",
     "prepublishOnly": "npm run build && npm run test",
     "docs": "typedoc src/index.ts"

--- a/crates/pjs-js-client/src/core/client.ts
+++ b/crates/pjs-js-client/src/core/client.ts
@@ -19,7 +19,6 @@ import {
   PJSError,
   PJSErrorType,
   StreamStats,
-  PerformanceMetrics,
   ProgressInfo
 } from '../types/index.js';
 import { FrameProcessor } from './frame-processor.js';
@@ -37,26 +36,24 @@ export class PJSClient extends EventEmitter {
   private _transport: Transport;
   private get transport(): Transport { return this._transport; }
   private frameProcessor: FrameProcessor;
-  private jsonReconstructor: JsonReconstructor;
   private sessionId?: string;
   private isConnected = false;
   private streams = new Map<string, StreamStats>();
 
   constructor(config: PJSClientConfig) {
     super();
-    
+
     // Validate and set default configuration
     this.config = this.validateAndNormalizeConfig(config);
-    
+
     // Initialize components
     this.frameProcessor = new FrameProcessor();
-    this.jsonReconstructor = new JsonReconstructor();
-    
+
     // Initialize transport based on configuration
     this._transport = this.createTransport();
 
     // Prevent unhandled 'error' event crashes when no user listener is registered
-    this.on('error', () => {});
+    this.on(PJSEvent.Error, () => {});
 
     // Set up event handlers
     this.setupEventHandlers();
@@ -117,7 +114,6 @@ export class PJSClient extends EventEmitter {
       this.isConnected = false;
       this.sessionId = undefined;
       this.streams.clear();
-      this.currentStreamId = undefined;
 
       this.emit(PJSEvent.Disconnected, {});
       
@@ -242,7 +238,7 @@ export class PJSClient extends EventEmitter {
     return {
       baseUrl: config.baseUrl.replace(/\/$/, ''), // Remove trailing slash
       transport: config.transport ?? TransportType.HTTP,
-      sessionId: config.sessionId,
+      sessionId: config.sessionId ?? '',
       headers: config.headers ?? {},
       timeout: config.timeout ?? 30000,
       debug: config.debug ?? false,
@@ -359,10 +355,8 @@ export class PJSClient extends EventEmitter {
           progressInfo.framesReceived++;
           progressInfo.elapsedTime = Date.now() - stats.startTime;
 
-          if (!stats.priorityDistribution[frame.priority]) {
-            stats.priorityDistribution[frame.priority] = 0;
-          }
-          stats.priorityDistribution[frame.priority]++;
+          stats.priorityDistribution[frame.priority] =
+            (stats.priorityDistribution[frame.priority] ?? 0) + 1;
 
           if (!progressInfo.prioritiesReceived.includes(frame.priority)) {
             progressInfo.prioritiesReceived.push(frame.priority);

--- a/crates/pjs-js-client/src/core/frame-processor.ts
+++ b/crates/pjs-js-client/src/core/frame-processor.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  Frame,
   FrameType,
   Priority,
   PatchOperation,

--- a/crates/pjs-js-client/src/parser/wasm-parser.ts
+++ b/crates/pjs-js-client/src/parser/wasm-parser.ts
@@ -10,6 +10,7 @@
  */
 
 import { PJSError, PJSErrorType, Frame, FrameType } from '../types/index.js';
+import { loadWasmModule } from '../utils/wasm-loader.js';
 import type { PriorityStream, FrameData, StreamStats } from 'pjs-wasm';
 
 export interface WasmParserOptions {
@@ -30,7 +31,9 @@ export interface StreamingCallbacks {
  */
 export class WasmParser {
   private parser: any = null;
+  private wasmModule: typeof import('pjs-wasm') | null = null;
   private wasmAvailable = false;
+  private initError: Error | null = null;
   private options: Required<WasmParserOptions>;
 
   constructor(options: WasmParserOptions = {}) {
@@ -56,10 +59,8 @@ export class WasmParser {
 
     try {
       // Dynamic import - won't fail if pjs-wasm is not installed
-      const wasmModule = await import('pjs-wasm');
-
-      // Initialize WASM (calls wasm_bindgen start function)
-      await wasmModule.default();
+      const wasmModule = await loadWasmModule();
+      this.wasmModule = wasmModule;
 
       // Create parser instance
       this.parser = new wasmModule.PjsParser();
@@ -77,6 +78,7 @@ export class WasmParser {
         console.warn('[PJS WASM] Not available, falling back to native JSON.parse:', error);
       }
       this.wasmAvailable = false;
+      this.initError = error as Error;
       return false;
     }
   }
@@ -153,16 +155,22 @@ export class WasmParser {
     callbacks: StreamingCallbacks,
     minPriority: number = 1
   ): Promise<void> {
-    if (!this.wasmAvailable) {
+    if (!this.wasmAvailable || !this.wasmModule) {
       throw new PJSError(
         PJSErrorType.InitializationError,
-        'WASM not available. Cannot use streaming API without WASM.'
+        this.initError
+          ? `WASM not available. Cannot use streaming API without WASM: ${this.initError.message}`
+          : 'WASM not available. Cannot use streaming API without WASM.',
+        undefined,
+        this.initError ?? undefined
       );
     }
 
+    const wasmModule = this.wasmModule;
+
     return new Promise<void>((resolve, reject) => {
       try {
-        const { PriorityStream } = this.wasmModule;
+        const { PriorityStream } = wasmModule;
         const stream: PriorityStream = new PriorityStream();
 
         // Set minimum priority
@@ -242,9 +250,7 @@ export class WasmParser {
     // Parse payload
     let payload: any;
     try {
-      payload = typeof frameData.getPayloadObject === 'function'
-        ? frameData.getPayloadObject()
-        : JSON.parse(frameData.payload);
+      payload = JSON.parse(frameData.payload);
     } catch (error) {
       throw new PJSError(
         PJSErrorType.ParseError,

--- a/crates/pjs-js-client/src/transport/http.ts
+++ b/crates/pjs-js-client/src/transport/http.ts
@@ -13,7 +13,6 @@ import { Frame, PJSError, PJSErrorType } from '../types/index.js';
  */
 export class HttpTransport extends Transport {
   private abortController?: AbortController;
-  private currentStreamEndpoint?: string;
 
   async connect(): Promise<ConnectResult> {
     try {
@@ -67,7 +66,6 @@ export class HttpTransport extends Transport {
     }
     
     this.isConnected = false;
-    this.currentStreamEndpoint = undefined;
   }
 
   async startStream(endpoint: string, options: StreamOptions): Promise<void> {
@@ -84,7 +82,6 @@ export class HttpTransport extends Transport {
     }
 
     this.abortController = new AbortController();
-    this.currentStreamEndpoint = endpoint;
 
     try {
       const url = new URL(`${this.config.baseUrl}/pjs/stream${endpoint}`);
@@ -148,8 +145,6 @@ export class HttpTransport extends Transport {
       this.abortController.abort();
       this.abortController = undefined;
     }
-    
-    this.currentStreamEndpoint = undefined;
   }
 
   // Private methods

--- a/crates/pjs-js-client/src/transport/wasm-backend.ts
+++ b/crates/pjs-js-client/src/transport/wasm-backend.ts
@@ -28,7 +28,8 @@
  */
 
 import { Transport, ConnectResult, StreamOptions } from './base.js';
-import { Frame, FrameType, PJSClientConfig, PJSError, PJSErrorType } from '../types/index.js';
+import { Frame, FrameType, PJSClientConfig, Priority, PJSError, PJSErrorType } from '../types/index.js';
+import { loadWasmModule } from '../utils/wasm-loader.js';
 import type { PriorityStream, FrameData, StreamStats } from 'pjs-wasm';
 
 /**
@@ -53,7 +54,7 @@ export interface WasmStreamOptions extends StreamOptions {
  * Provides client-side JSON streaming using WebAssembly, with no server communication.
  */
 export class WasmBackend extends Transport {
-  private wasmModule: any = null;
+  private wasmModule: typeof import('pjs-wasm') | null = null;
   private currentStream: PriorityStream | null = null;
   private wasmAvailable = false;
 
@@ -76,12 +77,7 @@ export class WasmBackend extends Transport {
     }
 
     try {
-      // Dynamic import of pjs-wasm
-      this.wasmModule = await import('pjs-wasm');
-
-      // Initialize WASM (automatically called via wasm_bindgen(start))
-      await this.wasmModule.default();
-
+      this.wasmModule = await loadWasmModule();
       this.wasmAvailable = true;
       this.isConnected = true;
 
@@ -98,8 +94,9 @@ export class WasmBackend extends Transport {
     } catch (error) {
       throw new PJSError(
         PJSErrorType.InitializationError,
-        'Failed to initialize WASM backend. Ensure pjs-wasm is installed.',
-        { error: (error as Error).message }
+        `Failed to initialize WASM backend: ${(error as Error).message}`,
+        { error: (error as Error).message },
+        error as Error
       );
     }
   }
@@ -152,21 +149,29 @@ export class WasmBackend extends Transport {
       );
     }
 
+    if (!this.wasmModule) {
+      throw new PJSError(
+        PJSErrorType.ConnectionError,
+        'WASM backend not initialized. Call connect() first.'
+      );
+    }
+
     try {
       // Create priority stream
       const { PriorityStream } = this.wasmModule;
-      this.currentStream = new PriorityStream();
+      const stream = new PriorityStream();
+      this.currentStream = stream;
 
       const minPriority = options.minPriority ?? 1;
-      this.currentStream.setMinPriority(minPriority);
+      stream.setMinPriority(minPriority);
 
       // Set up callbacks
-      this.currentStream.onFrame((frameData: FrameData) => {
+      stream.onFrame((frameData: FrameData) => {
         const frame = this.convertWasmFrame(frameData);
         this.emitFrame(frame);
       });
 
-      this.currentStream.onComplete((stats: StreamStats) => {
+      stream.onComplete((stats: StreamStats) => {
         if (this.config.debug) {
           console.log('[PJS WASM Backend] Stream complete:', {
             totalFrames: stats.totalFrames,
@@ -179,12 +184,12 @@ export class WasmBackend extends Transport {
         // Emit complete frame
         this.emitFrame({
           type: FrameType.Complete,
-          priority: 1,
+          priority: Priority.Background,
           total_frames: stats.totalFrames
         });
       });
 
-      this.currentStream.onError((error: string) => {
+      stream.onError((error: string) => {
         const pjsError = new PJSError(
           PJSErrorType.StreamError,
           `WASM streaming error: ${error}`,
@@ -202,7 +207,7 @@ export class WasmBackend extends Transport {
         });
       }
 
-      this.currentStream.start(options.jsonData);
+      stream.start(options.jsonData);
 
     } catch (error) {
       const pjsError = error instanceof PJSError
@@ -244,10 +249,7 @@ export class WasmBackend extends Transport {
     // Parse payload
     let payload: any;
     try {
-      // Use getPayloadObject() if available (zero-copy)
-      payload = typeof frameData.getPayloadObject === 'function'
-        ? frameData.getPayloadObject()
-        : JSON.parse(frameData.payload);
+      payload = JSON.parse(frameData.payload);
     } catch (error) {
       throw new PJSError(
         PJSErrorType.ParseError,

--- a/crates/pjs-js-client/src/types/index.ts
+++ b/crates/pjs-js-client/src/types/index.ts
@@ -239,7 +239,7 @@ export interface StreamStats {
   startTime: number;
   endTime?: number;
   totalFrames: number;
-  priorityDistribution: Record<Priority, number>;
+  priorityDistribution: Partial<Record<Priority, number>>;
   performance: PerformanceMetrics;
 }
 

--- a/crates/pjs-js-client/src/types/pjs-wasm.d.ts
+++ b/crates/pjs-js-client/src/types/pjs-wasm.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Fallback ambient type declarations for the optional `pjs-wasm` package.
+ *
+ * `pjs-wasm` is an `optionalDependencies` file-link to `../pjs-wasm/pkg`,
+ * the wasm-pack build output, which is absent until that crate is built
+ * (e.g. in CI jobs that don't build wasm). TypeScript only falls back to
+ * this declaration when the real package isn't resolvable on disk — when
+ * it is, the real generated `pjs_wasm.d.ts` takes precedence and this file
+ * has no effect. Mirrors the subset of that generated file actually used
+ * by this package; keep in sync if the wasm bindings' public API changes.
+ */
+declare module 'pjs-wasm' {
+  export interface FrameData {
+    type: string;
+    sequence: number;
+    priority: number;
+    payload: string;
+  }
+
+  export interface StreamStats {
+    totalFrames: number;
+    patchFrames: number;
+    bytesProcessed: number;
+    durationMs: number;
+  }
+
+  export class PjsParser {
+    constructor();
+    free(): void;
+    parse(json_str: string): any;
+    generateFrames(json_str: string, min_priority: number): any;
+    static version(): string;
+    static withConfig(config_builder: unknown): PjsParser;
+    static withSecurityConfig(security_config: unknown): PjsParser;
+  }
+
+  export class PriorityStream {
+    constructor();
+    free(): void;
+    onComplete(callback: (stats: StreamStats) => void): void;
+    onError(callback: (error: string) => void): void;
+    onFrame(callback: (frame: FrameData) => void): void;
+    setMinPriority(priority: number): void;
+    setSecurityConfig(config: unknown): void;
+    start(json_str: string): void;
+    static withConfig(config_builder: unknown): PriorityStream;
+  }
+
+  export function version(): string;
+
+  export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+  export default function init(
+    module_or_path?: InitInput | Promise<InitInput>
+  ): Promise<unknown>;
+}

--- a/crates/pjs-js-client/src/utils/index.ts
+++ b/crates/pjs-js-client/src/utils/index.ts
@@ -5,16 +5,14 @@
  */
 
 import {
-  PJSClient,
   PJSClientConfig,
   Frame,
   FrameType,
   Priority,
   JsonPath,
-  PJSError,
-  PJSErrorType,
   TransportType
 } from '../types/index.js';
+import type { PJSClient } from '../core/client.js';
 
 /**
  * Create a PJS client with smart defaults based on environment

--- a/crates/pjs-js-client/src/utils/wasm-loader.ts
+++ b/crates/pjs-js-client/src/utils/wasm-loader.ts
@@ -1,0 +1,64 @@
+/**
+ * WASM Module Loader
+ *
+ * Loads and initializes the pjs-wasm module for the current JavaScript runtime.
+ *
+ * The generated `pjs-wasm` init function defaults to fetching the `.wasm`
+ * binary via `fetch(new URL(...))` when called with no argument. Node's
+ * built-in `fetch` cannot load `file:` URLs, so in Node.js the binary is
+ * read from disk and passed directly to skip the fetch path. In browsers,
+ * the default fetch-based loading path is used unchanged.
+ */
+function isNodeRuntime(): boolean {
+  return typeof process !== 'undefined' && !!process.versions?.node;
+}
+
+// Cached across calls so WasmParser and WasmBackend initializing separately
+// in the same process don't each read the binary from disk.
+let cachedWasmBuffer: Buffer | null = null;
+
+/**
+ * Import and initialize the pjs-wasm module, selecting the correct
+ * initialization strategy for the current runtime.
+ */
+export async function loadWasmModule(): Promise<typeof import('pjs-wasm')> {
+  const wasmModule = await import('pjs-wasm');
+
+  if (isNodeRuntime()) {
+    // `require` is only available under CommonJS interop (Jest, CJS builds,
+    // or ESM consumers with a `require` shim). A pure-ESM Node context
+    // without one cannot resolve the on-disk binary path this way.
+    if (typeof require !== 'function') {
+      throw new Error(
+        'Cannot load pjs-wasm in this Node.js environment: no CommonJS `require` is ' +
+        'available to resolve the installed package location. Loading pjs-wasm from a ' +
+        'pure-ESM Node context without CJS interop is not yet supported.'
+      );
+    }
+
+    try {
+      const { readFile } = await import('fs/promises');
+      const { dirname, join } = await import('path');
+
+      const pkgPath = require.resolve('pjs-wasm/package.json');
+      const pkg = require(pkgPath) as { main?: unknown };
+      if (typeof pkg.main !== 'string') {
+        throw new Error(`pjs-wasm's package.json has no usable "main" field (got ${JSON.stringify(pkg.main)})`);
+      }
+
+      const wasmPath = join(dirname(pkgPath), pkg.main.replace(/\.js$/, '_bg.wasm'));
+      cachedWasmBuffer ??= await readFile(wasmPath);
+
+      await wasmModule.default(cachedWasmBuffer);
+    } catch (error) {
+      throw new Error(
+        `Failed to load the pjs-wasm binary for Node.js: ${(error as Error).message}`,
+        { cause: error }
+      );
+    }
+  } else {
+    await wasmModule.default();
+  }
+
+  return wasmModule;
+}

--- a/crates/pjs-js-client/tests/core/client.test.ts
+++ b/crates/pjs-js-client/tests/core/client.test.ts
@@ -6,13 +6,14 @@
 
 import { describe, test, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { PJSClient } from '../../src/core/client.js';
-import { 
-  Priority, 
-  TransportType, 
-  FrameType, 
-  PJSEvent, 
-  PJSError, 
-  PJSErrorType 
+import type { Transport } from '../../src/transport/base.js';
+import {
+  Priority,
+  TransportType,
+  FrameType,
+  PJSEvent,
+  PJSError,
+  Frame
 } from '../../src/types/index.js';
 
 describe('PJSClient', () => {
@@ -101,8 +102,8 @@ describe('PJSClient', () => {
 
   describe('Event System', () => {
     test('should emit connection events', async () => {
-      const connectListener = jest.fn();
-      const disconnectListener = jest.fn();
+      const connectListener = jest.fn<(data: { sessionId: string }) => void>();
+      const disconnectListener = jest.fn<(data: { reason?: string }) => void>();
 
       client.on(PJSEvent.Connected, connectListener);
       client.on(PJSEvent.Disconnected, disconnectListener);
@@ -133,16 +134,16 @@ describe('PJSClient', () => {
   describe('Streaming', () => {
     beforeEach(async () => {
       // Mock successful frames for streaming tests
-      const mockFrames = [
+      const mockFrames: Frame[] = [
         {
-          type: FrameType.Skeleton as FrameType.Skeleton,
+          type: FrameType.Skeleton,
           priority: Priority.Critical,
           data: { id: null, name: null },
           complete: false,
           timestamp: Date.now()
         },
         {
-          type: FrameType.Patch as FrameType.Patch,
+          type: FrameType.Patch,
           priority: Priority.High,
           patches: [
             { path: '$.id', value: 123, operation: 'set' as const },
@@ -151,14 +152,14 @@ describe('PJSClient', () => {
           timestamp: Date.now()
         },
         {
-          type: FrameType.Complete as FrameType.Complete,
+          type: FrameType.Complete,
           priority: Priority.Background,
           timestamp: Date.now()
         }
       ];
 
       // Mock transport to emit these frames
-      jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+      jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
         connect: () => Promise.resolve({ sessionId: 'test-session' }),
         startStream: () => {
           // Emit frames after a short delay
@@ -172,7 +173,7 @@ describe('PJSClient', () => {
         on: jest.fn(),
         removeListener: jest.fn(),
         disconnect: () => Promise.resolve()
-      });
+      } as unknown as Transport);
     });
 
     test('should stream data successfully', async () => {
@@ -185,8 +186,8 @@ describe('PJSClient', () => {
     });
 
     test('should call render callback during streaming', async () => {
-      const renderCallback = jest.fn();
-      const progressCallback = jest.fn();
+      const renderCallback = jest.fn<() => void>();
+      const progressCallback = jest.fn<() => void>();
 
       await client.stream('/api/test', {
         onRender: renderCallback,
@@ -219,16 +220,16 @@ describe('PJSClient', () => {
 
   describe('Statistics', () => {
     beforeEach(() => {
-      const mockFrames = [
+      const mockFrames: Frame[] = [
         {
-          type: FrameType.Skeleton as FrameType.Skeleton,
+          type: FrameType.Skeleton,
           priority: Priority.Critical,
           data: { id: null, name: null },
           complete: false,
           timestamp: Date.now()
         },
         {
-          type: FrameType.Patch as FrameType.Patch,
+          type: FrameType.Patch,
           priority: Priority.High,
           patches: [
             { path: '$.id', value: 1, operation: 'set' as const },
@@ -237,12 +238,12 @@ describe('PJSClient', () => {
           timestamp: Date.now()
         },
         {
-          type: FrameType.Complete as FrameType.Complete,
+          type: FrameType.Complete,
           priority: Priority.Background,
           timestamp: Date.now()
         }
       ];
-      jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+      jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
         connect: () => Promise.resolve({ sessionId: 'stats-session' }),
         startStream: () => {
           setTimeout(() => {
@@ -253,7 +254,7 @@ describe('PJSClient', () => {
         on: jest.fn(),
         removeListener: jest.fn(),
         disconnect: () => Promise.resolve()
-      });
+      } as unknown as Transport);
     });
 
     test('should track stream statistics', async () => {
@@ -298,7 +299,7 @@ describe('PJSClient', () => {
     });
 
     test('should validate frame structure', async () => {
-      const errorListener = jest.fn();
+      const errorListener = jest.fn<() => void>();
       client.on(PJSEvent.Error, errorListener);
 
       // Simulate invalid frame
@@ -310,7 +311,7 @@ describe('PJSClient', () => {
     });
 
     test('should handle protocol violations', async () => {
-      const errorListener = jest.fn();
+      const errorListener = jest.fn<() => void>();
       client.on(PJSEvent.Error, errorListener);
 
       // Simulate patch before skeleton

--- a/crates/pjs-js-client/tests/core/json-reconstructor.test.ts
+++ b/crates/pjs-js-client/tests/core/json-reconstructor.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, test, expect, beforeEach } from '@jest/globals';
 import { JsonReconstructor } from '../../src/core/json-reconstructor.js';
-import { FrameType, Priority } from '../../src/types/index.js';
+import { FrameType, Priority, SkeletonFrame } from '../../src/types/index.js';
 
 describe('JsonReconstructor', () => {
   let reconstructor: JsonReconstructor;
@@ -17,8 +17,8 @@ describe('JsonReconstructor', () => {
 
   describe('Skeleton Processing', () => {
     test('should process skeleton frame', () => {
-      const skeletonFrame = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeletonFrame: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: {
           user: {
@@ -58,8 +58,8 @@ describe('JsonReconstructor', () => {
     });
 
     test('should reject skeleton when already initialized', () => {
-      const skeletonFrame = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeletonFrame: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: { test: true },
         complete: false,
@@ -80,8 +80,8 @@ describe('JsonReconstructor', () => {
   describe('Patch Processing', () => {
     beforeEach(() => {
       // Initialize with skeleton
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: {
           user: {
@@ -297,8 +297,8 @@ describe('JsonReconstructor', () => {
       expect(reconstructor.isComplete()).toBe(false);
 
       // Add skeleton
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: { test: null },
         complete: false,
@@ -314,8 +314,8 @@ describe('JsonReconstructor', () => {
     });
 
     test('should provide metadata', () => {
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: { test: null },
         complete: false,
@@ -335,8 +335,8 @@ describe('JsonReconstructor', () => {
 
     test('should reset state correctly', () => {
       // Initialize with data
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: { test: 'value' },
         complete: false,
@@ -360,8 +360,8 @@ describe('JsonReconstructor', () => {
 
   describe('Memory Management', () => {
     test('should track memory usage', () => {
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: {
           largeArray: new Array(1000).fill('data'),
@@ -382,8 +382,8 @@ describe('JsonReconstructor', () => {
     });
 
     test('should handle large object reconstruction', () => {
-      const skeleton = {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+      const skeleton: SkeletonFrame = {
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: {
           items: []

--- a/crates/pjs-js-client/tests/integration/full-stream.test.ts
+++ b/crates/pjs-js-client/tests/integration/full-stream.test.ts
@@ -6,11 +6,13 @@
 
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import { PJSClient } from '../../src/core/client.js';
-import { 
-  Priority, 
-  TransportType, 
-  FrameType, 
-  PJSEvent 
+import type { Transport } from '../../src/transport/base.js';
+import {
+  Priority,
+  FrameType,
+  PJSEvent,
+  Frame,
+  SkeletonFrame
 } from '../../src/types/index.js';
 
 describe('Full Stream Integration', () => {
@@ -29,15 +31,15 @@ describe('Full Stream Integration', () => {
     const progressUpdates: number[] = [];
 
     // Set up event listeners
-    client.on(PJSEvent.Connected, () => events.push('connected'));
-    client.on(PJSEvent.SkeletonReady, () => events.push('skeleton_ready'));
-    client.on(PJSEvent.PatchApplied, () => events.push('patch_applied'));
-    client.on(PJSEvent.StreamComplete, () => events.push('stream_complete'));
+    client.on(PJSEvent.Connected, () => { events.push('connected'); });
+    client.on(PJSEvent.SkeletonReady, () => { events.push('skeleton_ready'); });
+    client.on(PJSEvent.PatchApplied, () => { events.push('patch_applied'); });
+    client.on(PJSEvent.StreamComplete, () => { events.push('stream_complete'); });
 
     // Mock transport for full workflow
-    const mockFrames = [
+    const mockFrames: Frame[] = [
       {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: {
           user: {
@@ -137,7 +139,7 @@ describe('Full Stream Integration', () => {
     ];
 
     // Mock transport implementation
-    jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+    jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
       connect: () => Promise.resolve({ sessionId: 'test-session-123' }),
       startStream: () => {
         // Simulate frames arriving over time
@@ -160,7 +162,7 @@ describe('Full Stream Integration', () => {
       on: jest.fn(),
       removeListener: jest.fn(),
       disconnect: () => Promise.resolve()
-    });
+    } as unknown as Transport);
 
     // Start streaming with callbacks
     const result = await client.stream('/api/user/profile', {
@@ -171,7 +173,7 @@ describe('Full Stream Integration', () => {
         });
       },
       onProgress: (progress) => {
-        progressUpdates.push(progress.completionPercentage);
+        progressUpdates.push(progress.completionPercentage ?? 0);
       }
     });
 
@@ -244,9 +246,9 @@ describe('Full Stream Integration', () => {
     const lowData: any[] = [];
 
     // Mock progressive frames
-    const mockFrames = [
+    const mockFrames: Frame[] = [
       {
-        type: FrameType.Skeleton as FrameType.Skeleton,
+        type: FrameType.Skeleton,
         priority: Priority.Critical,
         data: { status: null, user: { id: null }, content: null },
         complete: false,
@@ -293,7 +295,7 @@ describe('Full Stream Integration', () => {
     ];
 
     // Mock transport
-    jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+    jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
       connect: () => Promise.resolve({ sessionId: 'test-session-456' }),
       startStream: () => {
         mockFrames.forEach((frame, index) => {
@@ -306,7 +308,7 @@ describe('Full Stream Integration', () => {
       on: jest.fn(),
       removeListener: jest.fn(),
       disconnect: () => Promise.resolve()
-    });
+    } as unknown as Transport);
 
     await client.stream('/api/data', {
       onRender: (data, metadata) => {
@@ -357,17 +359,17 @@ describe('Full Stream Integration', () => {
     const errors: any[] = [];
 
     client.on(PJSEvent.Error, ({ error, context }) => {
-      errors.push({ error: error.message, context: context.operation });
+      errors.push({ error: error.message, context });
     });
 
     // Mock transport with error
-    jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+    jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
       connect: () => Promise.resolve({ sessionId: 'test-session-error' }),
       startStream: () => {
         // Send invalid frame after skeleton
         setTimeout(() => {
-          const skeleton = {
-            type: FrameType.Skeleton as FrameType.Skeleton,
+          const skeleton: SkeletonFrame = {
+            type: FrameType.Skeleton,
             priority: Priority.Critical,
             data: { test: null },
             complete: false,
@@ -390,7 +392,7 @@ describe('Full Stream Integration', () => {
       on: jest.fn(),
       removeListener: jest.fn(),
       disconnect: () => Promise.resolve()
-    });
+    } as unknown as Transport);
 
     try {
       await client.stream('/api/error-test');
@@ -409,13 +411,13 @@ describe('Full Stream Integration', () => {
     const stream2Results: any[] = [];
 
     // Mock different responses for different endpoints
-    jest.spyOn(client as any, 'transport', 'get').mockReturnValue({
+    jest.spyOn(client as unknown as { transport: Transport }, 'transport', 'get').mockReturnValue({
       connect: () => Promise.resolve({ sessionId: 'concurrent-test' }),
       startStream: (endpoint: string) => {
         if (endpoint === '/api/user1') {
           setTimeout(() => {
-            const skeleton = {
-              type: FrameType.Skeleton as FrameType.Skeleton,
+            const skeleton: SkeletonFrame = {
+              type: FrameType.Skeleton,
               priority: Priority.Critical,
               data: { user: { id: null, name: null } },
               complete: false,
@@ -452,15 +454,15 @@ describe('Full Stream Integration', () => {
       on: jest.fn(),
       removeListener: jest.fn(),
       disconnect: () => Promise.resolve()
-    });
+    } as unknown as Transport);
 
     // Start concurrent streams
     const promises = [
       client.stream('/api/user1', {
-        onRender: (data) => stream1Results.push(JSON.parse(JSON.stringify(data)))
+        onRender: (data) => { stream1Results.push(JSON.parse(JSON.stringify(data))); }
       }),
       client.stream('/api/user2', {
-        onRender: (data) => stream2Results.push(JSON.parse(JSON.stringify(data)))
+        onRender: (data) => { stream2Results.push(JSON.parse(JSON.stringify(data))); }
       })
     ];
 

--- a/crates/pjs-js-client/tests/integration/wasm-backend.test.ts
+++ b/crates/pjs-js-client/tests/integration/wasm-backend.test.ts
@@ -13,7 +13,7 @@ import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 import { WasmBackend, WasmStreamOptions } from '../../src/transport/wasm-backend.js';
-import { PJSClientConfig, FrameType, Frame, PJSError } from '../../src/types/index.js';
+import { PJSClientConfig, FrameType, Frame, PJSError, Priority } from '../../src/types/index.js';
 
 // Skip the entire suite when pjs-wasm/pkg is not built
 const wasmPkgAvailable = existsSync(resolve(process.cwd(), 'crates/pjs-wasm/pkg/package.json'))
@@ -28,9 +28,12 @@ describeWasm('WasmBackend Integration Tests', () => {
     config = {
       baseUrl: 'wasm://local',
       transport: 'wasm' as any,
+      sessionId: '',
+      headers: {},
       timeout: 30000,
-      retry: { maxRetries: 0, baseDelay: 0, maxDelay: 0 },
       bufferSize: 1024 * 64,
+      priorityThreshold: Priority.Background,
+      maxConcurrentStreams: 10,
       debug: false
     };
 

--- a/crates/pjs-js-client/tests/integration/wasm-parser.test.ts
+++ b/crates/pjs-js-client/tests/integration/wasm-parser.test.ts
@@ -1,0 +1,87 @@
+/**
+ * WasmParser Integration Tests
+ *
+ * Regression coverage for issue #338: WasmParser.stream() used to throw
+ * immediately because `this.wasmModule` was never assigned in initialize().
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { WasmParser } from '../../src/parser/wasm-parser.js';
+import { FrameType } from '../../src/types/index.js';
+
+// Skip the entire suite when pjs-wasm/pkg is not built
+const wasmPkgAvailable = existsSync(resolve(process.cwd(), 'crates/pjs-wasm/pkg/package.json'))
+  || existsSync(resolve(process.cwd(), '../pjs-wasm/pkg/package.json'));
+const describeWasm = wasmPkgAvailable ? describe : describe.skip;
+
+describeWasm('WasmParser Integration Tests', () => {
+  let parser: WasmParser;
+
+  beforeEach(() => {
+    parser = new WasmParser();
+  });
+
+  afterEach(() => {
+    parser.dispose();
+  });
+
+  test('should initialize WASM module successfully', async () => {
+    const initialized = await parser.initialize();
+
+    expect(initialized).toBe(true);
+    expect(parser.isWasmAvailable()).toBe(true);
+    expect(parser.getImplementation()).toBe('wasm');
+  });
+
+  test('should stream JSON with priority-based progressive delivery', async () => {
+    await parser.initialize();
+
+    const jsonData = JSON.stringify({
+      id: 123,
+      name: 'Alice',
+      email: 'alice@example.com',
+      bio: 'Software developer'
+    });
+
+    const frames: FrameType[] = [];
+    let completeStats: { totalFrames: number; patchFrames: number; durationMs: number } | undefined;
+
+    await parser.stream(
+      jsonData,
+      {
+        onFrame: (frame) => {
+          frames.push(frame.type);
+        },
+        onComplete: (stats) => {
+          completeStats = stats;
+        },
+        onError: (error) => {
+          throw error;
+        }
+      },
+      1
+    );
+
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames).toContain(FrameType.Skeleton);
+    expect(completeStats).toBeDefined();
+    expect(completeStats?.totalFrames).toBeGreaterThan(0);
+  });
+});
+
+// Does not require the pjs-wasm binary — runs unconditionally. Exercises the
+// early-return native-fallback guard, not the #338 bug itself; see
+// tests/parser/wasm-parser.test.ts for #338's actual regression coverage.
+describe('WasmParser (native fallback)', () => {
+  test('should reject stream() when WASM is not available', async () => {
+    const nativeParser = new WasmParser({ preferNative: true });
+    await nativeParser.initialize();
+
+    expect(nativeParser.isWasmAvailable()).toBe(false);
+    await expect(
+      nativeParser.stream('{"test": true}', {})
+    ).rejects.toThrow('WASM not available');
+  });
+});

--- a/crates/pjs-js-client/tests/parser/wasm-parser.test.ts
+++ b/crates/pjs-js-client/tests/parser/wasm-parser.test.ts
@@ -1,0 +1,102 @@
+/**
+ * WasmParser Unit Tests (mocked pjs-wasm)
+ *
+ * Regression coverage for issue #338: WasmParser.stream() destructured
+ * `this.wasmModule`, a field `initialize()` never assigned, so every call
+ * threw immediately. Mocks `loadWasmModule()` so this exercises the actual
+ * broken code path — `initialize()` storing the module, then `stream()`
+ * reading it back — without needing the real pjs-wasm binary, so it runs
+ * unconditionally in CI regardless of whether pjs-wasm/pkg is built.
+ */
+
+import { describe, test, expect, jest } from '@jest/globals';
+
+jest.mock('../../src/utils/wasm-loader.js', () => {
+  class FakePriorityStream {
+    private frameCallback: ((frame: unknown) => void) | null = null;
+    private completeCallback: ((stats: unknown) => void) | null = null;
+
+    onFrame(callback: (frame: unknown) => void): void {
+      this.frameCallback = callback;
+    }
+
+    onComplete(callback: (stats: unknown) => void): void {
+      this.completeCallback = callback;
+    }
+
+    onError(_callback: (error: string) => void): void {}
+
+    setMinPriority(_priority: number): void {}
+
+    start(jsonString: string): void {
+      this.frameCallback?.({
+        type: 'skeleton',
+        sequence: 0,
+        priority: 100,
+        payload: jsonString
+      });
+      this.completeCallback?.({
+        totalFrames: 1,
+        patchFrames: 0,
+        bytesProcessed: jsonString.length,
+        durationMs: 1
+      });
+    }
+
+    free(): void {}
+  }
+
+  class FakePjsParser {
+    parse(jsonString: string): unknown {
+      return JSON.parse(jsonString);
+    }
+
+    static version(): string {
+      return '0.0.0-fake';
+    }
+  }
+
+  return {
+    loadWasmModule: jest.fn(async () => ({
+      PjsParser: FakePjsParser,
+      PriorityStream: FakePriorityStream,
+      version: () => '0.0.0-fake',
+      default: async () => undefined
+    }))
+  };
+});
+
+import { WasmParser } from '../../src/parser/wasm-parser.js';
+import { FrameType } from '../../src/types/index.js';
+
+describe('WasmParser (mocked pjs-wasm)', () => {
+  test('stream() delivers frames after initialize() — this.wasmModule must be assigned', async () => {
+    const parser = new WasmParser();
+
+    const initialized = await parser.initialize();
+    expect(initialized).toBe(true);
+    expect(parser.isWasmAvailable()).toBe(true);
+
+    const frameTypes: FrameType[] = [];
+    let completed = false;
+
+    await parser.stream(
+      JSON.stringify({ id: 1 }),
+      {
+        onFrame: (frame) => {
+          frameTypes.push(frame.type);
+        },
+        onComplete: () => {
+          completed = true;
+        },
+        onError: (error) => {
+          throw error;
+        }
+      },
+      1
+    );
+
+    expect(frameTypes).toContain(FrameType.Skeleton);
+    expect(completed).toBe(true);
+  });
+});

--- a/crates/pjs-js-client/tests/setup.ts
+++ b/crates/pjs-js-client/tests/setup.ts
@@ -27,7 +27,7 @@ global.WebSocket = class MockWebSocket extends EventTarget {
     }, 10);
   }
 
-  send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+  send(_data: string | ArrayBufferLike | Blob | ArrayBufferView) {
     if (this.readyState !== MockWebSocket.OPEN) {
       throw new Error('WebSocket is not open');
     }
@@ -73,7 +73,7 @@ global.EventSource = class MockEventSource extends EventTarget {
 } as any;
 
 // Mock fetch with basic functionality
-global.fetch = jest.fn().mockImplementation((url: string, options?: RequestInit) => {
+global.fetch = jest.fn().mockImplementation((url: string, _options?: RequestInit) => {
   // Reject requests to invalid/unreachable hosts
   try {
     const parsed = new URL(url);
@@ -108,24 +108,6 @@ global.console = {
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn()
-};
-
-// Test utilities
-global.createMockFrame = (type: string, priority: number, data?: any) => ({
-  type,
-  priority,
-  timestamp: Date.now(),
-  ...(data && { data }),
-  ...(type === 'patch' && { patches: data?.patches || [] })
-});
-
-global.createMockClient = (config: any = {}) => {
-  const { PJSClient } = require('../src/core/client');
-  return new PJSClient({
-    baseUrl: 'http://localhost:3000',
-    debug: false,
-    ...config
-  });
 };
 
 // Cleanup after tests

--- a/crates/pjs-js-client/tsconfig.json
+++ b/crates/pjs-js-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2022.Array", "ES2022.Error", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
 "resolveJsonModule": true,

--- a/crates/pjs-js-client/tsconfig.wasm-drift.json
+++ b/crates/pjs-js-client/tsconfig.wasm-drift.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/types/pjs-wasm.d.ts"]
+}


### PR DESCRIPTION
## Summary

- Fixes #338: `WasmParser.stream()` threw immediately (`this.wasmModule` was never assigned in `initialize()`).
- Fixes #317: `WasmBackend.connect()` always failed in Node.js because the default wasm-bindgen init path uses `fetch()`, which cannot load `file:` URLs. A shared `loadWasmModule()` helper now detects Node.js and reads the `.wasm` binary from disk instead, reused by both `WasmBackend` and `WasmParser` (the latter had the same latent bug).
- Fixes #339: adds `npm run typecheck` to the `js-client-test` CI job and fixes the ~65 strict-mode TypeScript errors it surfaced. Since that job doesn't build the real `pjs-wasm` bindings, a fallback ambient module declaration (`src/types/pjs-wasm.d.ts`) lets typecheck succeed without them; a separate `wasm-types-drift` CI job typechecks against the real generated bindings so the shim can't silently drift from the real API.

## Notable behavior changes (documented in CHANGELOG)

- `WasmBackend`'s synthetic `Complete` frame now reports `priority: Priority.Background` (10) instead of the previously invalid hardcoded `1`.
- `StreamStats.priorityDistribution` is now typed `Partial<Record<Priority, number>>` instead of `Record<Priority, number>`.

## Known follow-up (not blocking, filed as a note for a future issue)

- `wasm-types-drift` only runs on wasm/rust PRs and pushes to `main` (dead `js` gating clause in its dependency chain skips it on JS-only PRs, including this one). Recommended follow-up: either gate `wasm-build`/`quality` on `js` too, or give the drift job its own build step.

## Test plan

- [x] `npm run typecheck` — 0 errors (pkg present and absent)
- [x] `npm run typecheck:wasm-drift` — 0 errors (pkg present); fails correctly on real API drift (verified)
- [x] `npm test` — 95 passed, 22 skipped (pre-existing, unrelated Jest/ESM limitation for two WASM-import suites), 0 failed
- [x] New regression test for #338 (`tests/parser/wasm-parser.test.ts`) verified to fail on the pre-fix code and pass on the fix
- [x] `wasm-types-drift` CI job verified to fail on a deliberately mutated real type and pass when reverted