### PR TITLE
fix(pjson-rs)!: remove redundant simd-avx2/simd-neon/simd-sse42 features

### DIFF
--- a/.github/instructions/parser.instructions.md
+++ b/.github/instructions/parser.instructions.md
@@ -26,13 +26,8 @@ cargo bench -p pjs-bench -- --baseline before
 
 ## SIMD Feature Flags
 
-Available optimizations (mutually exclusive except simd-auto):
-
-- `simd-auto` - Auto-detect best SIMD for platform (default)
-- `simd-sse42` - SSE 4.2
-- `simd-avx2` - AVX2
-- `simd-avx512` - AVX-512
-- `simd-neon` - ARM NEON
+- `simd-auto` - Enable the sonic-rs SIMD backend, runtime-dispatched to the best available instruction set (AVX-512/AVX2/SSE4.2/NEON) for the host CPU (default)
+- `simd-avx512` - x86_64-only. Additionally forwards to `sonic-rs/avx512`; requires `RUSTFLAGS="-C target-cpu=native"` to take effect
 
 ## Memory Safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING** `RateLimitError` (public on `pjson-rs`) gained a new `CapacityExceeded { max: usize }` variant as part of the #346 fix below. `RateLimitError` is not `#[non_exhaustive]`, so this breaks any external code exhaustively matching on it without a wildcard arm
+- **BREAKING** Removed the `simd-avx2`, `simd-neon`, and `simd-sse42` Cargo features from `pjson-rs`. All three compiled to identical behavior as `simd-auto` — they only ever gated the same coarse SIMD-enable switch in `crates/pjs-core/build.rs` (which sets the sonic-rs backend on or off), never a distinct per-ISA code path, and their README documentation incorrectly implied each one "forced" a specific instruction set. Builds passing `--features simd-avx2`/`simd-neon`/`simd-sse42` explicitly now fail with an unknown-feature error instead of silently accepting a redundant flag. Use `simd-auto` (default, runtime-dispatches to the best available instruction set; x86_64 and aarch64) or `simd-avx512` (x86_64-only, also forwards to `sonic-rs/avx512`) instead. `crates/pjs-bench`'s own disconnected copies of these features, along with the dead `features::has_simd()` helper that only ever reflected them, were also removed (closes #324)
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -405,8 +405,11 @@ crates/
 PJS uses feature flags to minimize compile times and binary size. Be mindful when adding dependencies:
 
 ### Core Features (Default)
-- `simd-auto` - Auto-detect SIMD support
+- `simd-auto` - Auto-detect SIMD support at runtime (x86_64 and aarch64)
 - `schema-validation` - Schema validation engine
+
+### SIMD Features
+- `simd-avx512` - Forwards to `sonic-rs/avx512` (x86_64-only; requires `RUSTFLAGS="-C target-cpu=native"` to take effect)
 
 ### Optional Features
 - `compression` - Schema-based compression

--- a/README.md
+++ b/README.md
@@ -217,11 +217,8 @@ cargo run --manifest-path crates/pjs-demo/Cargo.toml --bin simple-demo-server --
 
 | Feature | Description | Default |
 |---------|-------------|---------|
-| `simd-auto` | Auto-detect SIMD support at runtime | ✅ Yes |
-| `simd-avx2` | Force AVX2 SIMD path | No |
-| `simd-avx512` | Force AVX-512 SIMD path (sonic-rs) | No |
-| `simd-sse42` | Force SSE4.2 SIMD path | No |
-| `simd-neon` | Force ARM NEON SIMD path | No |
+| `simd-auto` | Enable the sonic-rs SIMD parser backend, which dispatches at runtime to the best available instruction set (AVX-512/AVX2/SSE4.2/NEON) for the host CPU | ✅ Yes |
+| `simd-avx512` | x86_64-only. Additionally forwards to `sonic-rs/avx512`; requires `RUSTFLAGS="-C target-cpu=native"` (or explicit `-C target-feature=+avx512f`) to actually take effect | No |
 | `schema-validation` | Schema validation engine | ✅ Yes |
 | `compression` | zlib/gzip/brotli/zstd decompression with per-session dictionaries | ✅ Yes |
 | `partial-parse` | Streaming partial JSON parsing (`jiter` backend) | No |

--- a/crates/pjs-bench/Cargo.toml
+++ b/crates/pjs-bench/Cargo.toml
@@ -27,9 +27,6 @@ dhat = { workspace = true }
 
 [features]
 default = ["streaming"]
-simd-auto = []
-simd-avx2 = []
-simd-sse42 = []
 streaming = []
 dhat-heap = []
 

--- a/crates/pjs-bench/src/lib.rs
+++ b/crates/pjs-bench/src/lib.rs
@@ -240,15 +240,6 @@ pub mod features {
     pub fn has_streaming() -> bool {
         cfg!(feature = "streaming")
     }
-
-    /// Check if SIMD features are available
-    pub fn has_simd() -> bool {
-        cfg!(any(
-            feature = "simd-auto",
-            feature = "simd-avx2",
-            feature = "simd-sse42"
-        ))
-    }
 }
 
 #[cfg(test)]
@@ -260,20 +251,6 @@ mod tests {
         let bench = BenchSuite::new();
         // StreamConfig doesn't have chunk_size method, just ensure config exists
         let _config = bench.config();
-    }
-
-    #[test]
-    #[allow(clippy::overly_complex_bool_expr)]
-    fn test_feature_detection() {
-        use crate::features;
-
-        // These will depend on compilation features
-        let has_streaming = features::has_streaming();
-        let has_simd = features::has_simd();
-
-        // Just ensure they return boolean values (always true, but validates API)
-        assert!(has_streaming || !has_streaming);
-        assert!(has_simd || !has_simd);
     }
 
     #[test]

--- a/crates/pjs-core/Cargo.toml
+++ b/crates/pjs-core/Cargo.toml
@@ -83,10 +83,7 @@ default = [
 
 # SIMD features
 simd-auto = []
-simd-avx2 = []
 simd-avx512 = ["sonic-rs/avx512"]
-simd-neon = []
-simd-sse42 = []
 
 # Process-wide allocator (opt-in; registers MiMalloc as #[global_allocator] on non-wasm targets)
 # Note: conflicts with any other crate in the binary that also declares #[global_allocator].

--- a/crates/pjs-core/build.rs
+++ b/crates/pjs-core/build.rs
@@ -1,25 +1,22 @@
 //! Build script for pjs-core.
 //!
-//! Translates `simd-*` Cargo features into source-level `cfg` gates so that
-//! `#[target_feature]`-annotated hot paths and the sonic-rs dependency are
-//! activated correctly for the current target.
+//! Translates the `simd-auto`/`simd-avx512` Cargo features into a single
+//! `cfg(pjs_simd)` gate (read by `Parser::new()` in `src/parser/mod.rs` to
+//! select the sonic-rs SIMD backend over the portable serde fallback).
 //!
-//! Cargo cannot pass `-C target-feature` from a build script to rustc.
-//! To genuinely activate SIMD in sonic-rs and elsewhere, the user must
-//! compile with `RUSTFLAGS="-C target-cpu=native"` (set in `.cargo/config.toml`
-//! at the workspace root by default). This script verifies that intent and
-//! warns when it is not satisfied.
+//! A Cargo feature being enabled does not by itself mean rustc was invoked
+//! with the matching `-C target-feature`; sonic-rs's own SIMD codegen still
+//! depends on that. Cargo cannot pass `-C target-feature` from a build
+//! script, so the user must compile with `RUSTFLAGS="-C target-cpu=native"`
+//! (set in `.cargo/config.toml` at the workspace root by default). This
+//! script checks that the requested target features are actually exposed to
+//! rustc and warns when they are not.
 
 use std::env;
 
 fn main() {
-    // Tell cargo about all custom cfgs we may emit so `--check-cfg` does not warn
+    // Tell cargo about the custom cfg we may emit so `--check-cfg` does not warn
     // (required on nightly with `unexpected_cfgs` lint).
-    println!("cargo::rustc-check-cfg=cfg(pjs_simd_avx2)");
-    println!("cargo::rustc-check-cfg=cfg(pjs_simd_avx512)");
-    println!("cargo::rustc-check-cfg=cfg(pjs_simd_sse42)");
-    println!("cargo::rustc-check-cfg=cfg(pjs_simd_neon)");
-    println!("cargo::rustc-check-cfg=cfg(pjs_simd_auto)");
     println!("cargo::rustc-check-cfg=cfg(pjs_simd)");
 
     // Re-run only when these inputs change.
@@ -32,50 +29,15 @@ fn main() {
     let has = |feat: &str| target_features.split(',').any(|f| f == feat);
 
     let want_auto = env::var_os("CARGO_FEATURE_SIMD_AUTO").is_some();
-    let want_avx2 = env::var_os("CARGO_FEATURE_SIMD_AVX2").is_some();
     let want_avx512 = env::var_os("CARGO_FEATURE_SIMD_AVX512").is_some();
-    let want_sse42 = env::var_os("CARGO_FEATURE_SIMD_SSE42").is_some();
-    let want_neon = env::var_os("CARGO_FEATURE_SIMD_NEON").is_some();
 
-    if want_auto {
-        println!("cargo::rustc-cfg=pjs_simd_auto");
-    }
-
-    // x86_64 features: AVX-512 implies AVX2 implies SSE4.2.
     if target_arch == "x86_64" {
-        let avx512_active = (want_avx512 || want_auto) && has("avx512f");
-        let avx2_active = avx512_active || ((want_avx2 || want_auto) && has("avx2"));
-        let sse42_active = avx2_active || ((want_sse42 || want_auto) && has("sse4.2"));
-
-        if avx512_active {
-            println!("cargo::rustc-cfg=pjs_simd_avx512");
-        }
-        if avx2_active {
-            println!("cargo::rustc-cfg=pjs_simd_avx2");
-        }
-        if sse42_active {
-            println!("cargo::rustc-cfg=pjs_simd_sse42");
-        }
-
         if want_avx512 && !has("avx512f") {
             println!(
                 "cargo::warning=feature `simd-avx512` is enabled but rustc was not invoked \
                  with AVX-512 target features. Set RUSTFLAGS=\"-C target-cpu=native\" or \
                  `-C target-feature=+avx512f` in .cargo/config.toml. \
                  SIMD codegen in sonic-rs will fall back to scalar."
-            );
-        }
-        if want_avx2 && !has("avx2") {
-            println!(
-                "cargo::warning=feature `simd-avx2` is enabled but rustc target features \
-                 lack `avx2`. Set RUSTFLAGS=\"-C target-cpu=native\" (recommended) or \
-                 `-C target-feature=+avx2`. sonic-rs SIMD path inactive."
-            );
-        }
-        if want_sse42 && !has("sse4.2") {
-            println!(
-                "cargo::warning=feature `simd-sse42` is enabled but rustc target features \
-                 lack `sse4.2`. Set RUSTFLAGS=\"-C target-cpu=native\"."
             );
         }
         if want_auto && !has("avx2") && !has("sse4.2") {
@@ -87,24 +49,14 @@ fn main() {
         }
     }
 
-    // aarch64: NEON is mandatory in the AArch64 base ISA, so it is essentially always present.
-    if target_arch == "aarch64" {
-        let neon_active = (want_neon || want_auto) && has("neon");
-        if neon_active {
-            println!("cargo::rustc-cfg=pjs_simd_neon");
-        }
-        if want_neon && !has("neon") {
-            println!(
-                "cargo::warning=feature `simd-neon` is enabled but rustc target features \
-                 lack `neon`. This is unusual on aarch64 — check your target triple."
-            );
-        }
-    }
+    // aarch64: NEON is mandatory in the AArch64 base ISA, so it is essentially always
+    // present — no per-feature gate is needed, `simd-auto` alone covers it via the
+    // umbrella `pjs_simd` cfg below.
 
     // Unsupported feature combinations on non-matching architectures: silently no-op.
     // sonic-rs already handles the runtime fallback.
 
-    if want_auto || want_avx2 || want_avx512 || want_sse42 || want_neon {
+    if want_auto || want_avx512 {
         println!("cargo::rustc-cfg=pjs_simd");
     }
 }

--- a/crates/pjs-core/src/parser/mod.rs
+++ b/crates/pjs-core/src/parser/mod.rs
@@ -43,9 +43,9 @@ pub struct Parser {
 impl Parser {
     /// Create new parser with default configuration.
     ///
-    /// Selects the sonic-rs SIMD backend when any `simd-*` Cargo feature is
-    /// enabled (which is the default via `simd-auto`). Without any `simd-*`
-    /// feature, falls back to the portable serde-based parser.
+    /// Selects the sonic-rs SIMD backend when `simd-auto` (the default) or
+    /// `simd-avx512` is enabled. Without either feature, falls back to the
+    /// portable serde-based parser.
     pub fn new() -> Self {
         Self {
             sonic: SonicParser::new(),


### PR DESCRIPTION
## Summary

- Removes `simd-avx2`/`simd-neon`/`simd-sse42` Cargo features from `pjson-rs`. Investigation during this fix found the original issue's "these are pure no-ops" premise was wrong — `crates/pjs-core/build.rs` wires all `simd-*` features into a real `cfg(pjs_simd)` gate that `Parser::new()` reads to pick the sonic-rs SIMD backend over the serde fallback. However, all three flags were exhaustively verified to be functionally *redundant aliases* of `simd-auto`: the umbrella cfg condition was purely feature-driven with no target-feature test, so enabling any of them alone always compiled to identical behavior as `simd-auto` alone, on every target/RUSTFLAGS combination. The per-ISA cfgs build.rs emitted for them were never consumed anywhere in `src`.
- Keeps `simd-auto` (default, runtime-dispatches to the best available instruction set) and `simd-avx512` (x86_64-only, the only flag with a genuinely distinct effect — forwards to `sonic-rs/avx512`).
- Corrects README.md, CONTRIBUTING.md, and `.github/instructions/parser.instructions.md`, which previously (and incorrectly) documented the removed flags as "forcing" a specific instruction set.
- Removes `pjs-bench`'s own disconnected duplicate `simd-auto`/`simd-avx2`/`simd-sse42` features and the dead `features::has_simd()` helper that only ever reflected them.
- Cleans up `build.rs`'s now fully-unconsumed per-flag cfg emission/warnings (including `pjs_simd_auto`/`pjs_simd_avx512`, found unconsumed by adversarial review during this fix) and rewrites its module doc to match current behavior.

## Breaking change

Builds passing `--features simd-avx2`/`simd-neon`/`simd-sse42` explicitly now fail to compile with an unknown-feature error instead of silently accepting a redundant flag. Use `simd-auto` or `simd-avx512` instead.

closes #324

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (993/993)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Manual build matrix: `simd-auto` alone, `simd-avx512` alone, `--no-default-features` (correctly falls back to `SimpleParser`), `--features simd-avx2` (correctly fails with unknown-feature error)
- [x] Independent adversarial critique pass (redundant-alias claim re-derived and confirmed exhaustive across build.rs branches; aarch64 path confirmed no silent behavior change)
- [x] Independent code review pass (approved)