### PR TITLE
docs(http): fix broken intra-doc link in HttpError doc comment

### DIFF
--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -757,7 +757,7 @@ pub enum PjsError {
     /// wrapped string to a client: this type's `IntoResponse` implementation
     /// (below), and any handler that builds a response body directly from
     /// the error (e.g. `metrics_handler` in
-    /// [`crate::infrastructure::http::metrics`], which bypasses
+    /// `crate::infrastructure::http::metrics`, which bypasses
     /// `IntoResponse`).
     ///
     /// The construction sites in `build_cors_layer` (private, this module)


### PR DESCRIPTION
## Summary
- Replace the broken intra-doc link `[`crate::infrastructure::http::metrics`]` in `PjsError::HttpError`'s doc comment with a plain code span, since that module is `#[cfg(feature = "metrics")]`-gated and the rustdoc gate builds without that feature enabled.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -p pjson-rs --all-targets --all-features -- -D warnings`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjson-rs`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features -p pjson-rs`

Fixes #387