### PR TITLE
fix(wasm): take SecurityConfig and PriorityConfigBuilder by reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `pjs-wasm`'s `PjsParser.withSecurityConfig` and `PriorityStream.setSecurityConfig` took `SecurityConfig` by value on the Rust side. Under wasm-bindgen, passing a `#[wasm_bindgen]` struct by value into an exported function transfers ownership into Rust and invalidates the JS-side wrapper, so sharing one `SecurityConfig` instance across a parser and a stream — the exact pattern documented in the README's "Security Limits" section and the crate's module docs — threw `Error: null pointer passed to rust` on the second call. Both now take `&SecurityConfig` and clone internally; the generated TypeScript signatures (`withSecurityConfig(security: SecurityConfig): PjsParser`, `setSecurityConfig(config: SecurityConfig): void`) are unchanged, so this is not a breaking change for JS/TS consumers — the same `SecurityConfig` instance can now safely be passed to both calls (#404)
+- The identical by-value ownership-transfer hazard also affected `PjsParser.withConfig` and `PriorityStream.withConfig`, which both took `PriorityConfigBuilder` by value — sharing one `PriorityConfigBuilder` between a parser and a stream (the pattern shown in the README's API reference for `withConfig`) hit the same `Error: null pointer passed to rust`. Both now take `&PriorityConfigBuilder`; `PriorityConfigBuilder` gained `#[derive(Clone)]` and its internal `build_internal` clones from the reference. Generated TypeScript signatures are unchanged, so this is likewise not a breaking change for JS/TS consumers (#404)
+
 ## [0.6.3] - 2026-08-18
 
 ### Security

--- a/crates/pjs-wasm/README.md
+++ b/crates/pjs-wasm/README.md
@@ -194,7 +194,7 @@ const frames = parser.generateFrames('{"id": 1, "name": "Alice"}', 50);
 
 ##### `withConfig(config: PriorityConfigBuilder): PjsParser` (static)
 
-Create a parser with custom priority configuration.
+Create a parser with custom priority configuration. `config` is taken by reference, so the same `PriorityConfigBuilder` instance can also be applied to a `PriorityStream` via its own `withConfig`.
 
 **Parameters:**
 
@@ -210,6 +210,7 @@ Create a parser with custom priority configuration.
 const config = new PriorityConfigBuilder()
     .addCriticalField('user_id');
 const parser = PjsParser.withConfig(config);
+const stream = PriorityStream.withConfig(config);
 ```
 
 ### `version(): string`
@@ -230,6 +231,8 @@ console.log(version()); // e.g. "0.6.3"
 ## Security Limits
 
 `SecurityConfig` bounds JSON input size, nesting depth, array element count, and object key count to prevent DoS via oversized or maliciously crafted payloads. All limits are enforced during parsing, not just checked against the raw input size.
+
+`withSecurityConfig` and `setSecurityConfig` accept the config by reference, so one `SecurityConfig` instance can be shared across a `PjsParser` and a `PriorityStream` (the `setMax*` builder methods still consume and return a new instance, as usual — build the config fully before sharing it).
 
 ```javascript
 import { PjsParser, PriorityStream, SecurityConfig } from '@pjson/wasm';

--- a/crates/pjs-wasm/src/lib.rs
+++ b/crates/pjs-wasm/src/lib.rs
@@ -55,12 +55,17 @@
 //!
 //! # Security Configuration
 //!
+//! `SecurityConfig` can be shared across a `PjsParser` and a `PriorityStream`
+//! since both `withSecurityConfig` and `setSecurityConfig` take it by reference.
+//!
 //! ```javascript
-//! import { PriorityStream, SecurityConfig } from 'pjs-wasm';
+//! import { PjsParser, PriorityStream, SecurityConfig } from 'pjs-wasm';
 //!
 //! const security = new SecurityConfig()
 //!     .setMaxJsonSize(5 * 1024 * 1024)
 //!     .setMaxDepth(32);
+//!
+//! const parser = PjsParser.withSecurityConfig(security);
 //!
 //! const stream = new PriorityStream();
 //! stream.setSecurityConfig(security);

--- a/crates/pjs-wasm/src/parser.rs
+++ b/crates/pjs-wasm/src/parser.rs
@@ -64,6 +64,8 @@ impl PjsParser {
     /// Create a parser with custom priority configuration.
     ///
     /// This allows you to customize which fields get which priorities.
+    /// Takes the builder by reference so the same `PriorityConfigBuilder`
+    /// instance can also be applied to a `PriorityStream` via `withConfig`.
     ///
     /// # Arguments
     ///
@@ -76,16 +78,17 @@ impl PjsParser {
     /// # Example
     ///
     /// ```javascript
-    /// import { PjsParser, PriorityConfigBuilder } from 'pjs-wasm';
+    /// import { PjsParser, PriorityStream, PriorityConfigBuilder } from 'pjs-wasm';
     ///
     /// const config = new PriorityConfigBuilder()
     ///   .addCriticalField('user_id')
     ///   .addHighField('display_name');
     ///
     /// const parser = PjsParser.withConfig(config);
+    /// const stream = PriorityStream.withConfig(config);
     /// ```
     #[wasm_bindgen(js_name = withConfig)]
-    pub fn with_config(config_builder: PriorityConfigBuilder) -> Self {
+    pub fn with_config(config_builder: &PriorityConfigBuilder) -> Self {
         let config = config_builder.build_internal();
         Self {
             priority_assigner: PriorityAssigner::with_config(config),
@@ -95,6 +98,9 @@ impl PjsParser {
 
     /// Create a parser with custom security configuration.
     ///
+    /// Takes the config by reference so the same `SecurityConfig` instance
+    /// can also be applied to a `PriorityStream` via `setSecurityConfig`.
+    ///
     /// # Arguments
     ///
     /// * `security_config` - A SecurityConfig with custom limits
@@ -102,19 +108,21 @@ impl PjsParser {
     /// # Example
     ///
     /// ```javascript
-    /// import { PjsParser, SecurityConfig } from 'pjs-wasm';
+    /// import { PjsParser, PriorityStream, SecurityConfig } from 'pjs-wasm';
     ///
     /// const security = new SecurityConfig()
     ///     .setMaxJsonSize(5 * 1024 * 1024)  // 5 MB
     ///     .setMaxDepth(32);
     ///
     /// const parser = PjsParser.withSecurityConfig(security);
+    /// const stream = new PriorityStream();
+    /// stream.setSecurityConfig(security);
     /// ```
     #[wasm_bindgen(js_name = withSecurityConfig)]
-    pub fn with_security_config(security_config: SecurityConfig) -> Self {
+    pub fn with_security_config(security_config: &SecurityConfig) -> Self {
         Self {
             priority_assigner: PriorityAssigner::new(),
-            security_config,
+            security_config: security_config.clone(),
         }
     }
 
@@ -385,7 +393,7 @@ mod tests {
     #[test]
     fn test_parser_with_config() {
         let config = PriorityConfigBuilder::new().add_critical_field("custom_id".to_string());
-        let _parser = PjsParser::with_config(config);
+        let _parser = PjsParser::with_config(&config);
         // Parser created successfully with custom config
     }
 
@@ -557,7 +565,7 @@ mod tests {
         let security = SecurityConfig::new()
             .set_max_json_size(1024)
             .set_max_depth(10);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
         assert_eq!(parser.security_config.max_json_size(), 1024);
         assert_eq!(parser.security_config.max_depth(), 10);
     }
@@ -599,7 +607,7 @@ mod tests {
     fn test_generate_frames_internal_respects_depth_limit() {
         // Create parser with shallow depth limit
         let security = SecurityConfig::new().set_max_depth(3);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
         let stream_id = StreamId::new();
 
         // Create nested structure deeper than limit
@@ -703,7 +711,7 @@ mod wasm_tests {
             .add_critical_field("user_id".to_string())
             .add_high_field("display_name".to_string());
 
-        let parser = PjsParser::with_config(config);
+        let parser = PjsParser::with_config(&config);
         let result = parser.generate_frames(r#"{"user_id": 123, "display_name": "Alice"}"#, 10);
         assert!(result.is_ok());
     }
@@ -754,7 +762,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_parse_input_too_large() {
         let security = SecurityConfig::new().set_max_json_size(100);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         // Create input larger than 100 bytes
         let large_input = format!(r#"{{"data": "{}"}}"#, "x".repeat(200));
@@ -773,7 +781,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_generate_frames_input_too_large() {
         let security = SecurityConfig::new().set_max_json_size(50);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         // Create input larger than 50 bytes
         let large_input = r#"{"id": 1, "name": "Alice", "bio": "This is a long biography"}"#;
@@ -792,7 +800,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_parse_array_too_large_rejected() {
         let security = SecurityConfig::new().set_max_array_elements(100);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         let large_array = format!(
             "[{}]",
@@ -816,7 +824,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_parse_nested_array_too_large_rejected() {
         let security = SecurityConfig::new().set_max_array_elements(100);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         let large_array = format!(
             "[{}]",
@@ -841,7 +849,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_parse_object_too_many_keys_rejected() {
         let security = SecurityConfig::new().set_max_object_keys(2);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         let result = parser.parse(r#"{"a": 1, "b": 2, "c": 3}"#);
 
@@ -858,7 +866,7 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_generate_frames_array_too_large_rejected() {
         let security = SecurityConfig::new().set_max_array_elements(100);
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         let large_array = format!(
             "[{}]",
@@ -915,7 +923,7 @@ mod wasm_tests {
             .set_max_json_size(1024 * 1024) // 1 MB
             .set_max_depth(32);
 
-        let parser = PjsParser::with_security_config(security);
+        let parser = PjsParser::with_security_config(&security);
 
         // Small input should work
         let result = parser.parse(r#"{"id": 1}"#);

--- a/crates/pjs-wasm/src/priority_config.rs
+++ b/crates/pjs-wasm/src/priority_config.rs
@@ -24,6 +24,7 @@ use wasm_bindgen::prelude::*;
 /// const parser = PjsParser.withConfig(config);
 /// ```
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct PriorityConfigBuilder {
     config: PriorityConfig,
 }
@@ -184,10 +185,10 @@ impl PriorityConfigBuilder {
 
     /// Build the final configuration (internal use).
     ///
-    /// This method consumes the builder and returns the configuration.
-    /// It's used internally by the parser and not exposed to JavaScript.
-    pub(crate) fn build_internal(self) -> PriorityConfig {
-        self.config
+    /// Clones the builder's configuration. It's used internally by the
+    /// parser and streaming API and not exposed to JavaScript.
+    pub(crate) fn build_internal(&self) -> PriorityConfig {
+        self.config.clone()
     }
 }
 

--- a/crates/pjs-wasm/src/streaming.rs
+++ b/crates/pjs-wasm/src/streaming.rs
@@ -162,6 +162,9 @@ impl PriorityStream {
 
     /// Create a PriorityStream with custom priority configuration.
     ///
+    /// Takes the builder by reference so the same `PriorityConfigBuilder`
+    /// instance can also be applied to a `PjsParser` via `withConfig`.
+    ///
     /// # Arguments
     ///
     /// * `config_builder` - Custom priority configuration
@@ -174,7 +177,7 @@ impl PriorityStream {
     /// const stream = PriorityStream.withConfig(config);
     /// ```
     #[wasm_bindgen(js_name = withConfig)]
-    pub fn with_config(config_builder: PriorityConfigBuilder) -> Self {
+    pub fn with_config(config_builder: &PriorityConfigBuilder) -> Self {
         let config = config_builder.build_internal();
         Self {
             priority_assigner: PriorityAssigner::with_config(config),
@@ -187,6 +190,9 @@ impl PriorityStream {
     }
 
     /// Set custom security limits.
+    ///
+    /// Takes the config by reference so the same `SecurityConfig` instance
+    /// can also be applied to a `PjsParser` via `withSecurityConfig`.
     ///
     /// # Arguments
     ///
@@ -201,8 +207,8 @@ impl PriorityStream {
     /// stream.setSecurityConfig(security);
     /// ```
     #[wasm_bindgen(js_name = setSecurityConfig)]
-    pub fn set_security_config(&mut self, config: SecurityConfig) {
-        self.security_config = config;
+    pub fn set_security_config(&mut self, config: &SecurityConfig) {
+        self.security_config = config.clone();
     }
 
     /// Set the minimum priority threshold.
@@ -651,9 +657,45 @@ mod wasm_tests {
     #[wasm_bindgen_test]
     fn test_stream_with_config() {
         let config = PriorityConfigBuilder::new().add_critical_field("user_id".to_string());
-        let stream = PriorityStream::with_config(config);
+        let stream = PriorityStream::with_config(&config);
         let result = stream.start(r#"{"user_id": 123}"#);
         assert!(result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_security_config_shared_between_parser_and_stream() {
+        // Regression test for #404: a single SecurityConfig instance must be
+        // usable by both PjsParser::with_security_config and
+        // PriorityStream::set_security_config without either call consuming it.
+        use crate::PjsParser;
+
+        let security = SecurityConfig::new()
+            .set_max_json_size(1024)
+            .set_max_depth(10);
+
+        let parser = PjsParser::with_security_config(&security);
+        let mut stream = PriorityStream::new();
+        stream.set_security_config(&security);
+
+        assert!(parser.parse(r#"{"id": 1}"#).is_ok());
+        assert!(stream.start(r#"{"id": 1}"#).is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_priority_config_builder_shared_between_parser_and_stream() {
+        // Regression test for #404 (same by-value hazard, different type): a
+        // single PriorityConfigBuilder instance must be usable by both
+        // PjsParser::with_config and PriorityStream::with_config without
+        // either call consuming it.
+        use crate::PjsParser;
+
+        let config = PriorityConfigBuilder::new().add_critical_field("id".to_string());
+
+        let parser = PjsParser::with_config(&config);
+        let stream = PriorityStream::with_config(&config);
+
+        assert!(parser.parse(r#"{"id": 1}"#).is_ok());
+        assert!(stream.start(r#"{"id": 1}"#).is_ok());
     }
 
     #[wasm_bindgen_test]
@@ -664,7 +706,7 @@ mod wasm_tests {
 
         let security = SecurityConfig::new().set_max_array_elements(2);
         let mut stream = PriorityStream::new();
-        stream.set_security_config(security);
+        stream.set_security_config(&security);
 
         let received: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
         let received_clone = received.clone();


### PR DESCRIPTION
## Summary

- `PjsParser::withSecurityConfig`, `PriorityStream::setSecurityConfig`, `PjsParser::withConfig`, and `PriorityStream::withConfig` took a `#[wasm_bindgen]` struct (`SecurityConfig` / `PriorityConfigBuilder`) by value. Under wasm-bindgen this transfers ownership into Rust and invalidates the JS-side wrapper, so sharing one config instance across a parser and a stream - the pattern documented in the README - threw `Error: null pointer passed to rust` on the second call.
- All four now take a reference and clone internally. Generated TypeScript signatures are unchanged, so this is not a breaking change for JS/TS consumers. `PriorityConfigBuilder` gained `Clone` to support this.
- Updated README.md, module docs, and doc comments demonstrating the affected patterns to show the now-safe shared-instance usage.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1028/1028)
- [x] `cargo test --workspace --doc --all-features`
- [x] `wasm-pack test crates/pjs-wasm --node` (28/28, including two new regression tests exercising the shared-instance scenario through actual wasm-bindgen glue)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps -p pjs-wasm`
- [x] Manually re-ran the exact reproduction script from #404 against a `wasm-pack build --target nodejs` build - no longer throws

Closes #404