### PR TITLE
fix(pjson-rs): type SessionFilters.state and remove duplicate DTO conversion traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `pjs-demo`'s `interactive-demo-server` `/pjs-streaming` endpoint's `enable_streaming` query parameter is now wired up and authoritative when explicitly set (overriding `Accept`-header sniffing in either direction), instead of being an inert, dead-code field; both this endpoint and `/api/info` now document that it only requests the skeleton-only response — full SSE/chunked delivery is tracked separately (#163) (#399)
+- **BREAKING** `SearchSessionsQuery.filters.state` (`application::queries::SessionFilters::state`) is now typed as the domain `SessionState` enum instead of an unvalidated `String` — a typo like `state: "activ"` previously matched zero sessions silently instead of being rejected. The HTTP `GET /pjs/sessions/search?state=` query parameter now requires one of `SessionState`'s exact serialized spellings (`Initializing`, `Active`, `Closing`, `Completed`, `Failed`) and rejects anything else with `400` and the API's standard `{"error": ...}` JSON body — **this includes previously-working lowercase or mixed-case values** (e.g. `?state=active`, `?state=COMPLETED`), which matched case-insensitively under the old string-based repository comparison and now fail. `?state=` (present but empty) also now rejects with `400` instead of silently matching zero sessions (#414)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `pjs-demo`'s `crates/pjs-demo/src/servers/performance_comparison.rs` — dead source with no `[[bin]]` entry and no `mod` declaration, never compiled by any build, referencing APIs (`StreamProcessor::process_json`) that no longer exist and a request schema mismatched with its own front-end HTML. Follow-up work originally scoped to it (`estimate_priority_distribution`, tracked as #405) no longer applies to any running server (#399)
+- **BREAKING** `pjson-rs`'s `application::dto::{ToDto, FromDto}` traits and their `Priority`/`Id<T>` implementations — they duplicated the standard `From`/`TryFrom` impls already defined on the same DTO types for no added behavior. Callers of `.to_dto()` migrate to `.into()`; callers of `.from_dto(x)` migrate to `x.try_into()` (`Priority`) or `x.into()` (`Id<T>`, which cannot fail) (#413)
 
 ## [0.6.3] - 2026-08-18
 

--- a/crates/pjs-core/src/application/dto/id_dto.rs
+++ b/crates/pjs-core/src/application/dto/id_dto.rs
@@ -3,11 +3,7 @@
 //! Handles serialization/deserialization of `Id<T>` domain objects
 //! while keeping domain layer clean of serialization concerns.
 
-use crate::application::dto::priority_dto::{FromDto, ToDto};
-use crate::domain::{
-    DomainError,
-    value_objects::{Id, IdMarker, SessionMarker, StreamMarker},
-};
+use crate::domain::value_objects::{Id, IdMarker, SessionMarker, StreamMarker};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use uuid::Uuid;
@@ -69,20 +65,6 @@ impl<T: IdMarker> From<IdDto<T>> for Id<T> {
     }
 }
 
-impl<T: IdMarker> ToDto<IdDto<T>> for Id<T> {
-    fn to_dto(self) -> IdDto<T> {
-        IdDto::from(self)
-    }
-}
-
-impl<T: IdMarker> FromDto<IdDto<T>> for Id<T> {
-    type Error = DomainError;
-
-    fn from_dto(dto: IdDto<T>) -> Result<Self, Self::Error> {
-        Ok(Id::from(dto))
-    }
-}
-
 impl<T: IdMarker> std::fmt::Display for IdDto<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.uuid)
@@ -110,7 +92,7 @@ mod tests {
 
         assert_eq!(deserialized.uuid(), dto.uuid());
 
-        let domain_session_id = Id::from_dto(deserialized).unwrap();
+        let domain_session_id = Id::from(deserialized);
         assert_eq!(domain_session_id.as_uuid(), session_id.as_uuid());
     }
 
@@ -138,10 +120,10 @@ mod tests {
     fn test_conversion_traits() {
         let session_id = SessionId::new();
 
-        let dto = session_id.to_dto();
+        let dto: SessionIdDto = session_id.into();
         assert_eq!(dto.uuid(), session_id.as_uuid());
 
-        let converted = SessionId::from_dto(dto).unwrap();
+        let converted = SessionId::from(dto);
         assert_eq!(converted.as_uuid(), session_id.as_uuid());
     }
 

--- a/crates/pjs-core/src/application/dto/mod.rs
+++ b/crates/pjs-core/src/application/dto/mod.rs
@@ -11,7 +11,7 @@ pub mod schema_dto;
 
 pub use id_dto::{IdDto, SessionIdDto, StreamIdDto};
 pub use json_data_dto::JsonDataDto;
-pub use priority_dto::{FromDto, PriorityDto, ToDto};
+pub use priority_dto::PriorityDto;
 pub use schema_dto::{
     SchemaDefinitionDto, SchemaMetadataDto, SchemaRegistrationDto, ValidationErrorDto,
     ValidationRequestDto, ValidationResultDto,

--- a/crates/pjs-core/src/application/dto/priority_dto.rs
+++ b/crates/pjs-core/src/application/dto/priority_dto.rs
@@ -44,37 +44,6 @@ impl TryFrom<PriorityDto> for Priority {
     }
 }
 
-/// Utility trait for converting domain objects to DTOs
-pub trait ToDto<T> {
-    /// Convert this domain object into its DTO representation.
-    fn to_dto(self) -> T;
-}
-
-impl ToDto<PriorityDto> for Priority {
-    fn to_dto(self) -> PriorityDto {
-        PriorityDto::from(self)
-    }
-}
-
-/// Utility trait for converting DTOs to domain objects
-pub trait FromDto<T> {
-    /// Error returned when the DTO cannot be reconstructed into a valid domain object.
-    type Error;
-
-    /// Convert a DTO into its domain representation, validating invariants.
-    fn from_dto(dto: T) -> Result<Self, Self::Error>
-    where
-        Self: Sized;
-}
-
-impl FromDto<PriorityDto> for Priority {
-    type Error = DomainError;
-
-    fn from_dto(dto: PriorityDto) -> Result<Self, Self::Error> {
-        Priority::try_from(dto)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,7 +63,7 @@ mod tests {
         assert_eq!(deserialized.value(), 100);
 
         // Test conversion back to domain
-        let domain_priority = Priority::from_dto(deserialized).unwrap();
+        let domain_priority = Priority::try_from(deserialized).unwrap();
         assert_eq!(domain_priority, Priority::CRITICAL);
     }
 
@@ -108,15 +77,26 @@ mod tests {
     }
 
     #[test]
+    fn test_try_from_invalid_priority_dto_fails() {
+        // `PriorityDto` is `#[serde(transparent)]` over a bare `u8` and derives
+        // `Deserialize` directly, so it can be built from wire data that bypasses
+        // `PriorityDto::new`'s validation entirely.
+        let invalid_dto: PriorityDto = serde_json::from_str("0").unwrap();
+
+        let result = Priority::try_from(invalid_dto);
+        assert!(matches!(result, Err(DomainError::InvalidPriority(_))));
+    }
+
+    #[test]
     fn test_conversion_traits() {
         let priority = Priority::HIGH;
 
-        // Test ToDto trait
-        let dto = priority.to_dto();
+        // Test From trait
+        let dto: PriorityDto = priority.into();
         assert_eq!(dto.value(), 80);
 
-        // Test FromDto trait
-        let converted = Priority::from_dto(dto).unwrap();
+        // Test TryFrom trait
+        let converted = Priority::try_from(dto).unwrap();
         assert_eq!(converted, Priority::HIGH);
     }
 }

--- a/crates/pjs-core/src/application/handlers/query_handlers.rs
+++ b/crates/pjs-core/src/application/handlers/query_handlers.rs
@@ -3,6 +3,7 @@
 use crate::{
     application::{ApplicationError, ApplicationResult, handlers::QueryHandlerGat, queries::*},
     domain::{
+        SessionState,
         entities::Stream,
         ports::{
             FrameStoreGat, Pagination, SessionQueryCriteria, SortOrder as RepoSortOrder,
@@ -157,13 +158,8 @@ where
             // is unchanged. An explicit `filters.state` opts out of that
             // default and matches only the requested state(s), expired or not.
             let (states, exclude_expired) = match query.filters.state {
-                Some(state) => (Some(vec![state]), false),
-                None => (
-                    Some(vec![
-                        crate::domain::SessionState::Active.as_str().to_string(),
-                    ]),
-                    true,
-                ),
+                Some(state) => (Some(vec![state.as_str().to_string()]), false),
+                None => (Some(vec![SessionState::Active.as_str().to_string()]), true),
             };
 
             let criteria = SessionQueryCriteria {
@@ -1643,7 +1639,7 @@ mod tests {
 
         let query = SearchSessionsQuery {
             filters: SessionFilters {
-                state: Some("active".to_owned()),
+                state: Some(SessionState::Active),
                 ..Default::default()
             },
             sort_by: None,
@@ -1923,21 +1919,25 @@ mod tests {
 
     /// Locks in the exact-match state filter semantics that replaced the old
     /// in-process substring match (see `matches_filters`, removed in #391).
-    /// Under the old behavior a partial word like "complet" would still have
-    /// matched a "Completed" session; the new criteria-based path requires an
-    /// exact (case-insensitive) match, consistent with `GetActiveSessionsQuery`.
+    /// `SessionFilters::state` is now typed as `SessionState` (#414), so a
+    /// partial word like "complet" is rejected at compile time rather than
+    /// silently substring-matching a "Completed" session; only a fellow
+    /// non-matching variant can be exercised as the negative case here.
+    /// The HTTP-boundary rejection of an actual malformed/partial `state`
+    /// string (e.g. `?state=complet`) is covered separately by
+    /// `axum_adapter::tests::search_sessions_route_rejects_unknown_state`.
     #[tokio::test]
-    async fn test_search_sessions_state_filter_is_exact_not_substring() {
+    async fn test_search_sessions_state_filter_matches_only_specified_variant() {
         let repository = Arc::new(MockRepository::new());
         let mut session = make_session(None);
         session.close().unwrap(); // Active -> Completed
         repository.add_session(session);
         let handler = SessionQueryHandler::new(repository);
 
-        // Partial word: would have matched under the old substring semantics.
-        let partial_query = SearchSessionsQuery {
+        // Non-matching variant: must not match the Completed session.
+        let non_matching_query = SearchSessionsQuery {
             filters: SessionFilters {
-                state: Some("complet".to_owned()),
+                state: Some(SessionState::Failed),
                 ..Default::default()
             },
             sort_by: None,
@@ -1945,14 +1945,14 @@ mod tests {
             limit: None,
             offset: None,
         };
-        let result = QueryHandlerGat::handle(&handler, partial_query).await;
+        let result = QueryHandlerGat::handle(&handler, non_matching_query).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().sessions.len(), 0);
 
-        // Full word, case-insensitive: still matches.
+        // Matching variant: matches exactly.
         let exact_query = SearchSessionsQuery {
             filters: SessionFilters {
-                state: Some("COMPLETED".to_owned()),
+                state: Some(SessionState::Completed),
                 ..Default::default()
             },
             sort_by: None,

--- a/crates/pjs-core/src/application/queries/mod.rs
+++ b/crates/pjs-core/src/application/queries/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::application::dto::{PriorityDto, SessionIdDto, StreamIdDto};
 use crate::domain::{
+    SessionState,
     aggregates::{
         StreamSession,
         stream_session::{SessionHealth, SessionStats},
@@ -99,8 +100,11 @@ pub struct SearchSessionsQuery {
 /// Session filtering criteria
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SessionFilters {
-    /// Match sessions whose state equals this value.
-    pub state: Option<String>,
+    /// Match sessions whose state equals this value exactly (case-sensitive, no
+    /// substring matching — e.g. `SessionState::Active`, not `"active"` or `"activ"`).
+    /// Accepted spellings are exactly [`SessionState`]'s serialized variant names:
+    /// `Initializing`, `Active`, `Closing`, `Completed`, `Failed`.
+    pub state: Option<SessionState>,
     /// Match sessions created at or after this timestamp.
     pub created_after: Option<DateTime<Utc>>,
     /// Match sessions created at or before this timestamp.

--- a/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
+++ b/crates/pjs-core/src/infrastructure/http/axum_adapter.rs
@@ -25,6 +25,7 @@ use crate::{
         query_handlers::{SessionQueryHandler, StreamQueryHandler, SystemQueryHandler},
     },
     domain::{
+        SessionState,
         aggregates::stream_session::SessionHealth,
         entities::Frame,
         ports::{
@@ -705,6 +706,21 @@ pub(crate) fn parse_session_and_stream_id(
     Ok((session_id, stream_id))
 }
 
+/// Parse a raw `state` query-string value into a [`SessionState`], mapping failure to
+/// [`PjsError::InvalidSessionState`].
+///
+/// Kept as a raw `String` on [`SearchSessionsParams`] (rather than typing the field itself
+/// as `SessionState`) so a bad value is rejected here, inside the handler, with the API's
+/// standard JSON error envelope — not by axum's `Query` extractor, which fails before the
+/// handler runs and responds with a plain-text body inconsistent with every other 4xx this
+/// API returns. Accepts only the exact spellings [`SessionState`] serializes as (e.g.
+/// `"Active"`), matching [`SessionState::as_str`] — lowercase or mixed-case input is
+/// rejected, unlike the pre-#414 substring/case-insensitive repository match.
+pub(crate) fn parse_session_state(raw: String) -> Result<SessionState, PjsError> {
+    serde_json::from_value(serde_json::Value::String(raw.clone()))
+        .map_err(|_| PjsError::InvalidSessionState(raw))
+}
+
 /// Pagination parameters
 #[derive(Debug, Deserialize)]
 pub struct PaginationParams {
@@ -718,6 +734,12 @@ pub struct PaginationParams {
 #[derive(Debug, Deserialize)]
 pub struct SearchSessionsParams {
     /// Match sessions whose state equals this value.
+    ///
+    /// Must be one of [`SessionState`]'s exact serialized spellings, case-sensitive —
+    /// `Initializing`, `Active`, `Closing`, `Completed`, or `Failed` — or the request is
+    /// rejected with `400`. Parsed via an internal helper rather than typed directly, so
+    /// the rejection goes through the API's standard JSON error envelope instead of axum's
+    /// raw `Query`-extractor rejection body.
     pub state: Option<String>,
     /// Field name to sort by; ignored if not in the allowed sort field list.
     pub sort_by: Option<String>,
@@ -767,6 +789,10 @@ pub enum PjsError {
     #[error("Invalid priority: {0}")]
     InvalidPriority(String),
 
+    /// Provided session state filter does not match any `SessionState` variant.
+    #[error("Invalid session state: {0}")]
+    InvalidSessionState(String),
+
     /// Generic HTTP-layer error not covered by other variants.
     ///
     /// # Invariant
@@ -814,6 +840,7 @@ impl IntoResponse for PjsError {
             PjsError::InvalidSessionId(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             PjsError::InvalidStreamId(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             PjsError::InvalidPriority(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+            PjsError::InvalidSessionState(_) => (StatusCode::BAD_REQUEST, self.to_string()),
             PjsError::HttpError(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
 
@@ -1326,6 +1353,87 @@ mod tests {
 
         let resp = router.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// #414: an exact, correctly-cased `state` value is accepted end-to-end through the
+    /// real router — the `Query<SearchSessionsParams>` extractor plus `parse_session_state`
+    /// inside `search_sessions` must not reject a value matching `SessionState::as_str()`.
+    #[tokio::test]
+    async fn search_sessions_route_accepts_valid_state() {
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let repository = Arc::new(MockRepository::new());
+        let event_publisher = Arc::new(MockEventPublisher);
+        let stream_store = Arc::new(MockStreamStore);
+        let state = PjsAppState::new(repository, event_publisher, stream_store);
+
+        let router =
+            create_pjs_router_with_config::<MockRepository, MockEventPublisher, MockStreamStore>(
+                &HttpServerConfig::default(),
+            )
+            .expect("router should build")
+            .with_state(state);
+
+        let req = Request::builder()
+            .uri("/pjs/sessions/search?state=Active")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// #414: an unrecognized `state` value must be rejected with a `400` carrying the
+    /// API's standard `{"error": ...}` JSON envelope (via `PjsError::InvalidSessionState`),
+    /// not axum's raw `Query`-extractor rejection body — see impl-critic gap S2. Also
+    /// exercises the case-sensitivity break called out in the CHANGELOG: `"active"`
+    /// (lowercase) previously matched via the repository's case-insensitive comparison
+    /// and now must be rejected, since `SessionState` only deserializes its exact
+    /// spellings (e.g. `"Active"`).
+    #[tokio::test]
+    async fn search_sessions_route_rejects_unknown_state() {
+        use axum::body::to_bytes;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let repository = Arc::new(MockRepository::new());
+        let event_publisher = Arc::new(MockEventPublisher);
+        let stream_store = Arc::new(MockStreamStore);
+        let state = PjsAppState::new(repository, event_publisher, stream_store);
+
+        let router =
+            create_pjs_router_with_config::<MockRepository, MockEventPublisher, MockStreamStore>(
+                &HttpServerConfig::default(),
+            )
+            .expect("router should build")
+            .with_state(state);
+
+        let req = Request::builder()
+            .uri("/pjs/sessions/search?state=active")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let content_type = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            content_type.starts_with("application/json"),
+            "rejection must use the API's JSON envelope, got content-type: {content_type}"
+        );
+
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("error").is_some_and(|e| e.is_string()),
+            "body must match the standard {{\"error\": ...}} envelope, got: {json}"
+        );
     }
 
     /// End-to-end HTTP smoke test for the frame-generation route added in issue #230.

--- a/crates/pjs-core/src/infrastructure/http/handlers/sessions.rs
+++ b/crates/pjs-core/src/infrastructure/http/handlers/sessions.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     infrastructure::http::axum_adapter::{
         CreateSessionRequest, CreateSessionResponse, PaginationParams, PjsAppState, PjsError,
-        SearchSessionsParams, SessionHealthResponse, parse_session_id,
+        SearchSessionsParams, SessionHealthResponse, parse_session_id, parse_session_state,
     },
 };
 
@@ -170,9 +170,10 @@ where
         "descending" | "desc" => Some(SortOrder::Descending),
         _ => None,
     });
+    let session_state = params.state.map(parse_session_state).transpose()?;
     let query = SearchSessionsQuery {
         filters: SessionFilters {
-            state: params.state,
+            state: session_state,
             created_after: None,
             created_before: None,
             client_info: None,


### PR DESCRIPTION
## Summary

Two related P2 application-layer type-safety fixes in pjson-rs, grouped into one PR per triage:

- **#413** — `application::dto::{ToDto, FromDto}` traits duplicated the standard `From`/`TryFrom` impls already defined for the same DTO types (`Priority`/`PriorityDto`, `Id<T>`/`IdDto<T>`), with no behavioral difference between the two APIs. Removed `ToDto`/`FromDto` and standardized on `From`/`TryFrom`.
- **#414** — `SessionFilters::state` was `Option<String>` despite the domain already defining a `SessionState` enum for exactly this concept; an invalid/misspelled state matched zero sessions silently instead of failing at the API boundary. `SessionFilters::state` is now `Option<SessionState>`. The HTTP layer parses the raw query string via a `parse_session_state` helper (mirroring the existing `parse_session_id`) so invalid values return `400` through the API's standard `{"error": ...}` JSON envelope rather than axum's raw extractor rejection.

Both are breaking changes, documented in `CHANGELOG.md`.

## Breaking changes

- `application::dto::{ToDto, FromDto}` traits removed — migrate `.to_dto()` to `.into()`, `.from_dto(x)` to `x.try_into()` (`Priority`) or `x.into()` (`Id<T>`).
- `GET /pjs/sessions/search?state=` now requires one of `SessionState`'s exact serialized spellings (`Initializing`, `Active`, `Closing`, `Completed`, `Failed`) and rejects anything else with `400` — including previously-working lowercase/mixed-case values that matched case-insensitively under the old string comparison. An empty `?state=` now also rejects with `400`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1050 passed)
- [x] `cargo test --workspace --doc --all-features`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] New tests: `test_try_from_invalid_priority_dto_fails`, `search_sessions_route_accepts_valid_state`, `search_sessions_route_rejects_unknown_state`, `test_search_sessions_state_filter_matches_only_specified_variant`

Closes #413, closes #414